### PR TITLE
Dartzee perf #1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ compileTestKotlin {
 task runDev(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 
-    args 'devMode'
+    args 'devMode', 'trueLaunch'
     main 'dartzee.main.DartsMainKt'
 }
 

--- a/src/main/kotlin/dartzee/dartzee/DartzeeCalculator.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeCalculator.kt
@@ -24,14 +24,15 @@ class DartzeeCalculator: AbstractDartzeeCalculator()
     }
 
     private fun isValidDartCombination(darts: List<Dart>, rule: DartzeeRuleDto) =
-            isValidCombination(darts.map{ DartboardSegment("${it.score}_${it.segmentType}")}, rule)
+            isValidCombination(darts.map { DartboardSegment("${it.score}_${it.segmentType}") }, rule)
 
     fun isValidCombination(combination: List<DartboardSegment>,
-                                    rule: DartzeeRuleDto): Boolean
+                           rule: DartzeeRuleDto,
+                           cachedResults: MutableMap<List<DartboardSegment>, Boolean> = mutableMapOf()): Boolean
     {
         return isValidCombinationForTotalRule(combination, rule.totalRule)
                 && isValidFromMisses(combination, rule)
-                && isValidCombinationForDartRule(combination, rule.getDartRuleList(), rule.inOrder)
+                && isValidCombinationForDartRule(combination, rule.getDartRuleList(), rule.inOrder, cachedResults)
     }
 
     override fun getValidSegments(rule: DartzeeRuleDto, dartsSoFar: List<Dart>): DartzeeRuleCalculationResult
@@ -46,7 +47,8 @@ class DartzeeCalculator: AbstractDartzeeCalculator()
 
         val allPossibilities = generateAllPossibilities(dartsSoFar)
 
-        val validCombinations = allPossibilities.filter { isValidCombinationCached(it, rule, cachedCombinationResults) }
+        val validCombinations = allPossibilities.filter {
+            isValidCombination(it, rule, cachedCombinationResults) }
 
         val validSegments = validCombinations.map { it[dartsSoFar.size] }.distinct()
 
@@ -54,14 +56,6 @@ class DartzeeCalculator: AbstractDartzeeCalculator()
         val allProbabilities = allPossibilities.map { mapCombinationToProbability(it) }.sum()
 
         return DartzeeRuleCalculationResult(validSegments, validCombinations.size, allPossibilities.size, validPixelPossibility, allProbabilities)
-    }
-    private fun isValidCombinationCached(combination: List<DartboardSegment>,
-                                 rule: DartzeeRuleDto,
-                                 cachedResults: MutableMap<List<DartboardSegment>, Boolean>): Boolean
-    {
-        return isValidCombinationForTotalRule(combination, rule.totalRule)
-                && isValidFromMisses(combination, rule)
-                && isValidCombinationForDartRule(combination, rule.getDartRuleList(), rule.inOrder, cachedResults)
     }
     private fun isValidFromMisses(combination: List<DartboardSegment>, rule: DartzeeRuleDto): Boolean
     {

--- a/src/main/kotlin/dartzee/main/DartsMain.kt
+++ b/src/main/kotlin/dartzee/main/DartsMain.kt
@@ -8,9 +8,18 @@ import dartzee.utils.DARTS_VERSION_NUMBER
 import dartzee.utils.DartsDebugExtension
 import javax.swing.JOptionPane
 import javax.swing.UIManager
+import kotlin.system.exitProcess
 
 fun main(args: Array<String>)
 {
+    DartsClient.parseProgramArguments(args)
+
+    if (!DartsClient.trueLaunch)
+    {
+        Runtime.getRuntime().exec("cmd /c start javaw -Xms256m -Xmx512m -jar Dartzee.jar trueLaunch")
+        exitProcess(0)
+    }
+
     Debug.initialise(ScreenCache.debugConsole)
     checkForUserName()
     DialogUtil.init(MessageDialogFactory())
@@ -24,10 +33,7 @@ fun main(args: Array<String>)
     val mainScreen = ScreenCache.mainScreen
     Thread.setDefaultUncaughtExceptionHandler(DebugUncaughtExceptionHandler())
 
-    val heapSize = Runtime.getRuntime().totalMemory()
-    Debug.append("Running with heap size: $heapSize")
-
-    DartsClient.parseProgramArguments(args)
+    DartsClient.logArgumentState()
 
     Debug.sendingEmails = !DartsClient.devMode
     ClientEmailer.tryToSendUnsentLogs()

--- a/src/main/kotlin/dartzee/main/DartsMain.kt
+++ b/src/main/kotlin/dartzee/main/DartsMain.kt
@@ -47,7 +47,7 @@ fun main(args: Array<String>)
 private fun checkForUserName()
 {
     var userName: String? = CoreRegistry.instance.get(CoreRegistry.INSTANCE_STRING_USER_NAME, "")
-    if (!userName!!.isEmpty())
+    if (userName?.isNotEmpty() == true)
     {
         return
     }

--- a/src/main/kotlin/dartzee/main/DartsMain.kt
+++ b/src/main/kotlin/dartzee/main/DartsMain.kt
@@ -24,6 +24,9 @@ fun main(args: Array<String>)
     val mainScreen = ScreenCache.mainScreen
     Thread.setDefaultUncaughtExceptionHandler(DebugUncaughtExceptionHandler())
 
+    val heapSize = Runtime.getRuntime().totalMemory()
+    Debug.append("Running with heap size: $heapSize")
+
     DartsClient.parseProgramArguments(args)
 
     Debug.sendingEmails = !DartsClient.devMode

--- a/src/main/kotlin/dartzee/object/DartboardSegment.kt
+++ b/src/main/kotlin/dartzee/object/DartboardSegment.kt
@@ -58,8 +58,8 @@ private fun getRoughSize(type: Int, score: Int): Int
  */
 data class DartboardSegment(val scoreAndType : String)
 {
-    var type : Int
-    var score : Int
+    val type : Int
+    val score : Int
 
     //The Points this segment contains
     val points = mutableListOf<Point>()

--- a/src/main/kotlin/dartzee/object/DartboardSegment.kt
+++ b/src/main/kotlin/dartzee/object/DartboardSegment.kt
@@ -10,6 +10,8 @@ const val SEGMENT_TYPE_INNER_SINGLE = 4
 const val SEGMENT_TYPE_MISS = 5
 const val SEGMENT_TYPE_MISSED_BOARD = 6
 
+const val MISS_FUDGE_FACTOR = 1805
+
 fun getGolfScoreForSegment(type: Int): Int
 {
     return when (type)
@@ -30,6 +32,24 @@ fun getMultiplier(type: Int): Int
         SEGMENT_TYPE_TREBLE -> 3
         SEGMENT_TYPE_MISS, SEGMENT_TYPE_MISSED_BOARD -> 0
         else -> 1
+    }
+}
+
+/**
+ * Hard-coded values based on counting the points in a 500x500 rendered dartboard.
+ */
+private fun getRoughScoringArea(): Double = 96173.0 + MISS_FUDGE_FACTOR
+private fun getRoughSize(type: Int, score: Int): Int
+{
+    if (score == 25) return if (type == SEGMENT_TYPE_DOUBLE) 137 else 716
+    return when (type)
+    {
+        SEGMENT_TYPE_DOUBLE -> 441 //8820
+        SEGMENT_TYPE_TREBLE -> 275 //5500
+        SEGMENT_TYPE_OUTER_SINGLE -> 2464 //49280
+        SEGMENT_TYPE_INNER_SINGLE -> 1586 //31720
+        SEGMENT_TYPE_MISS -> MISS_FUDGE_FACTOR
+        else -> 3321
     }
 }
 
@@ -88,5 +108,9 @@ data class DartboardSegment(val scoreAndType : String)
         val xMax = otherYPts.map { it.x }.max() ?: return true
 
         return pt.x == xMax || pt.x == xMin || pt.y == yMax || pt.y == yMin
+    }
+
+    fun getRoughProbability(): Double {
+        return getRoughSize(type, score).toDouble() / getRoughScoringArea()
     }
 }

--- a/src/main/kotlin/dartzee/object/DartsClient.kt
+++ b/src/main/kotlin/dartzee/object/DartsClient.kt
@@ -11,6 +11,7 @@ object DartsClient
     var traceReadSql = true
     var traceWriteSql = true
     var logSecret: String = PreferenceUtil.getStringValue(PREFERENCES_STRING_LOG_SECRET)
+    var trueLaunch = false
     var sqlMaxDuration = MAX_SQL_DURATION
     var operatingSystem = System.getProperty("os.name").toLowerCase(Locale.ENGLISH)
     var justUpdated = false
@@ -19,10 +20,18 @@ object DartsClient
     fun parseProgramArguments(args: Array<String>)
     {
         args.forEach { parseProgramArgument(it) }
+    }
 
-        if (devMode) Debug.appendBanner("Running in dev mode")
-        if (justUpdated) Debug.append("I've just updated")
-        if (!logSecret.isEmpty()) Debug.append("logSecret is present - will email diagnostics")
+    fun logArgumentState()
+    {
+        Debug.appendBanner("Running in dev mode", devMode)
+        Debug.append("I've just updated", justUpdated)
+        Debug.append("logSecret is present - will email diagnostics", logSecret.isNotEmpty())
+
+        val rt = Runtime.getRuntime()
+        val maxMb = rt.maxMemory() / (1024*1024)
+        val totalMb = rt.totalMemory() / (1024*1024)
+        Debug.append("Heap settings - Max [$maxMb MB], Total [$totalMb MB]")
     }
 
     private fun parseProgramArgument(arg: String)
@@ -36,6 +45,7 @@ object DartsClient
             "justUpdated" -> justUpdated = true
             "devMode" -> devMode = true
             "logSecret" -> logSecret = argValue
+            "trueLaunch" -> trueLaunch = true
             else -> Debug.append("Unexpected program argument: $arg")
         }
     }

--- a/src/main/resources/update/update.bat
+++ b/src/main/resources/update/update.bat
@@ -13,5 +13,5 @@ ren Dartzee.jar Dartzee_OLD.jar
 ren %3 Dartzee.jar
 del Dartzee_OLD.jar
 
-start javaw -jar Dartzee.jar justUpdated
+start javaw -jar -Xms256m -Xmx512m Dartzee.jar justUpdated trueLaunch
 exit

--- a/src/main/resources/update/update.bat
+++ b/src/main/resources/update/update.bat
@@ -13,5 +13,5 @@ ren Dartzee.jar Dartzee_OLD.jar
 ren %3 Dartzee.jar
 del Dartzee_OLD.jar
 
-start javaw -jar -Xms256m -Xmx512m Dartzee.jar justUpdated trueLaunch
+start javaw -Xms256m -Xmx512m -jar Dartzee.jar justUpdated trueLaunch
 exit


### PR DESCRIPTION
Trello: https://trello.com/c/UhSB2MV7

Initial stab at improving performance of dartzee rule calculation. Need to give it a test as a bundled JAR under the original conditions to see if more improvements are needed (I suspect they are...)

This PR:

 - Forces the JAR to start with reasonable memory settings (`256mb` initial, with `512mb` max). 
 - Removes the cached dartboard from `DartzeeCalculator`, which will hopefully lower the memory footprint anyway.
 - Calculates all possible segments once, then filters this based on darts thrown in subsequent calculations (rather than building up the list of ~600,000 possibilities every time).

Still some ways we can get cleverer to avoid work, e.g. detecting if a rule equates to "Anything" (and therefore not bothering to calculate at all). And can always fall back on a progress bar / requiring a manual trigger for calculation if it's still not fast enough. 