### PR TITLE
In memory game stats

### DIFF
--- a/src/main/kotlin/dartzee/achievements/AchievementUtil.kt
+++ b/src/main/kotlin/dartzee/achievements/AchievementUtil.kt
@@ -17,7 +17,6 @@ import dartzee.db.GAME_TYPE_X01
 import dartzee.db.PlayerEntity
 import dartzee.utils.DatabaseUtil
 import java.sql.SQLException
-import kotlin.streams.toList
 
 fun getNotBustSql(): String
 {
@@ -217,7 +216,7 @@ fun insertForCheckoutCompleteness(playerId: String, gameId: String, counter: Int
     val whereSql = "PlayerId = '$playerId' AND AchievementRef = $achievementRef"
 
     val achievementRows = AchievementEntity().retrieveEntities(whereSql)
-    val hitDoubles = achievementRows.stream().mapToInt{it.achievementCounter}.toList()
+    val hitDoubles = achievementRows.map { it.achievementCounter }
     if (!hitDoubles.contains(counter))
     {
         AchievementEntity.factoryAndSave(achievementRef, playerId, gameId, counter)

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
@@ -12,7 +12,6 @@ import dartzee.utils.ResourceCache
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.net.URL
-import kotlin.streams.toList
 
 class AchievementX01CheckoutCompleteness : AbstractAchievementRowPerGame()
 {
@@ -91,7 +90,7 @@ class AchievementX01CheckoutCompleteness : AbstractAchievementRowPerGame()
     {
         super.initialiseFromDb(achievementRows, player)
 
-        hitDoubles = achievementRows.stream().map{row -> row.achievementCounter}.toList().toMutableList()
+        hitDoubles = achievementRows.map { row -> row.achievementCounter }.toMutableList()
     }
 
     override fun changeIconColor(img : BufferedImage, newColor: Color)

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
@@ -90,7 +90,7 @@ class AchievementX01CheckoutCompleteness : AbstractAchievementRowPerGame()
     {
         super.initialiseFromDb(achievementRows, player)
 
-        hitDoubles = achievementRows.map { row -> row.achievementCounter }.toMutableList()
+        hitDoubles = achievementRows.map { it.achievementCounter }.toMutableList()
     }
 
     override fun changeIconColor(img : BufferedImage, newColor: Color)

--- a/src/main/kotlin/dartzee/core/obj/HashMapCount.kt
+++ b/src/main/kotlin/dartzee/core/obj/HashMapCount.kt
@@ -5,14 +5,9 @@ import java.util.ArrayList
 import java.util.HashMap
 import kotlin.Comparator
 
-
-
 class HashMapCount<K>: HashMap<K, Int>()
 {
-    fun getTotalCount() : Int
-    {
-        return values.sum()
-    }
+    fun getTotalCount() = values.sum()
 
     fun incrementCount(key: K, amount: Int = 1): Int
     {
@@ -22,10 +17,7 @@ class HashMapCount<K>: HashMap<K, Int>()
         return newVal
     }
 
-    fun getCount(key: K): Int
-    {
-        return get(key) ?: return 0
-    }
+    fun getCount(key: K) = get(key) ?: 0
 
     /**
      * These ONLY WORK FOR INTEGER KEYS

--- a/src/main/kotlin/dartzee/core/obj/HashMapCount.kt
+++ b/src/main/kotlin/dartzee/core/obj/HashMapCount.kt
@@ -11,7 +11,7 @@ class HashMapCount<K>: HashMap<K, Int>()
 {
     fun getTotalCount() : Int
     {
-        return values.stream().mapToInt{v -> v}.sum()
+        return values.sum()
     }
 
     fun incrementCount(key: K, amount: Int = 1): Int

--- a/src/main/kotlin/dartzee/core/util/ExtensionFunctions.kt
+++ b/src/main/kotlin/dartzee/core/util/ExtensionFunctions.kt
@@ -10,6 +10,9 @@ fun <E> MutableList<E>.addUnique(element: E)
 
 fun <K: Comparable<K>, V> Map<K, V>.getSortedValues(): List<V> = entries.sortedBy { it.key }.map { it.value }
 
+fun List<Int>.minOrZero() = min() ?: 0
+fun List<Int>.maxOrZero() = max() ?: 0
+
 inline fun <T, R : Comparable<R>> Iterable<T>.sortedBy(descending: Boolean, crossinline selector: (T) -> R?): List<T> {
     return if (descending) this.sortedByDescending(selector) else this.sortedBy(selector)
 }

--- a/src/main/kotlin/dartzee/core/util/ExtensionFunctions.kt
+++ b/src/main/kotlin/dartzee/core/util/ExtensionFunctions.kt
@@ -8,6 +8,8 @@ fun <E> MutableList<E>.addUnique(element: E)
     }
 }
 
+fun <K: Comparable<K>, V> Map<K, V>.getSortedValues(): List<V> = entries.sortedBy { it.key }.map { it.value }
+
 inline fun <T, R : Comparable<R>> Iterable<T>.sortedBy(descending: Boolean, crossinline selector: (T) -> R?): List<T> {
     return if (descending) this.sortedByDescending(selector) else this.sortedBy(selector)
 }

--- a/src/main/kotlin/dartzee/game/state/PlayerState.kt
+++ b/src/main/kotlin/dartzee/game/state/PlayerState.kt
@@ -1,8 +1,16 @@
 package dartzee.game.state
 
+import dartzee.`object`.Dart
 import dartzee.db.ParticipantEntity
 import dartzee.screen.game.scorer.DartsScorer
 
 data class PlayerState<S: DartsScorer>(val pt: ParticipantEntity,
                                        val scorer: S,
-                                       val lastRoundNumber: Int)
+                                       val lastRoundNumber: Int,
+                                       val darts: MutableList<List<Dart>> = mutableListOf())
+{
+    fun addDarts(darts: List<Dart>)
+    {
+        this.darts.add(darts)
+    }
+}

--- a/src/main/kotlin/dartzee/object/GameLauncher.kt
+++ b/src/main/kotlin/dartzee/object/GameLauncher.kt
@@ -104,11 +104,7 @@ object GameLauncher
         {
             allGames.forEach {
                 val panel = scrn.addGameToMatch(it)
-                when (it.rowId)
-                {
-                    originalGameId -> panel.loadGame()
-                    else -> panel.preLoad()
-                }
+                panel.loadGame()
             }
 
             scrn.displayGame(originalGameId)

--- a/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
@@ -97,6 +97,8 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard>(parent: AbstractDar
     /**
      * Stuff that will ultimately get refactored off into a GameState thingy
      */
+    fun getPlayerStates() = hmPlayerNumberToState.getSortedValues()
+    protected fun getParticipants() = hmPlayerNumberToState.entries.sortedBy { it.key }.map { it.value.pt }
     protected fun getCurrentPlayerId() = getCurrentParticipant().playerId
     private fun getCurrentPlayerState() = getPlayerState(currentPlayerNumber)
     private fun getPlayerState(playerNumber: Int) = hmPlayerNumberToState[playerNumber]!!
@@ -477,7 +479,7 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard>(parent: AbstractDar
         }
     }
 
-    protected fun getParticipants() = hmPlayerNumberToState.entries.sortedBy { it.key }.map { it.value.pt }
+
 
     /**
      * Should I stop throwing?
@@ -744,7 +746,7 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard>(parent: AbstractDar
             panelCenter.remove(dartboard)
             panelCenter.add(statsPanel!!, BorderLayout.CENTER)
 
-            statsPanel.showStats(getParticipants())
+            statsPanel.showStats(getPlayerStates())
         }
         else
         {

--- a/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
@@ -291,9 +291,6 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard>(parent: AbstractDar
         loadParticipants(gameId)
         loadScoresAndCurrentPlayer(gameId)
 
-        //Paint the dartboard
-        dartboard.paintDartboardCached()
-
         //If the game is over, do some extra stuff to sort the screen out
         val dtFinish = gameEntity.dtFinish
         if (!isEndOfTime(dtFinish))
@@ -302,6 +299,9 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard>(parent: AbstractDar
         }
         else
         {
+            //Paint the dartboard
+            dartboard.paintDartboardCached()
+
             nextTurn()
         }
     }
@@ -752,6 +752,12 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard>(parent: AbstractDar
         {
             panelCenter.remove(statsPanel)
             panelCenter.add(dartboard, BorderLayout.CENTER)
+
+            //We might not have painted it if this is a complete, loaded game
+            if (dartboard.dartboardImage == null)
+            {
+                dartboard.paintDartboardCached()
+            }
         }
 
         panelCenter.revalidate()

--- a/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
@@ -122,11 +122,6 @@ class DartsMatchScreen(val match: DartsMatchEntity, players: MutableList<PlayerE
         {
             val title = selectedTab.gameTitle
             setTitle(title)
-
-            if (selectedTab.pendingLoad)
-            {
-                selectedTab.loadGameInCatch()
-            }
         }
         else
         {

--- a/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
@@ -14,10 +14,10 @@ import javax.swing.SwingConstants
 import javax.swing.event.ChangeEvent
 import javax.swing.event.ChangeListener
 
-class DartsMatchScreen(val match: DartsMatchEntity, players: MutableList<PlayerEntity>):
+class DartsMatchScreen(val match: DartsMatchEntity, players: List<PlayerEntity>):
         AbstractDartsGameScreen(match.getPlayerCount(), match.gameType), ChangeListener
 {
-    private val matchPanel = MatchSummaryPanel()
+    private val matchPanel = MatchSummaryPanel(match)
     private val tabbedPane = JTabbedPane(SwingConstants.TOP)
     val hmGameIdToTab = mutableMapOf<String, DartsGamePanel<*, *>>()
 
@@ -28,7 +28,7 @@ class DartsMatchScreen(val match: DartsMatchEntity, players: MutableList<PlayerE
         tabbedPane.addTab("Match", matchPanel)
         tabbedPane.addChangeListener(this)
 
-        matchPanel.init(match, players)
+        matchPanel.init(players)
 
         title = match.getMatchDesc()
     }
@@ -44,6 +44,8 @@ class DartsMatchScreen(val match: DartsMatchEntity, players: MutableList<PlayerE
         //Initialise some basic properties of the tab, such as visibility of components etc
         val tab = DartsGamePanel.factory(this, game)
         tab.initBasic(match.getPlayerCount())
+
+        matchPanel.addGameTab(tab)
 
         //Add the single game tab and set the parent window to be visible
         tabbedPane.addTab("#" + game.localId, tab)

--- a/src/main/kotlin/dartzee/screen/game/GamePanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/GamePanelGolf.kt
@@ -39,6 +39,7 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity) : Ga
         for (i in 1..totalRounds)
         {
             val darts = hmRoundToDarts[i]!!
+            darts.forEach { it.setGolfHole(i) }
             scorer.addDarts(darts)
         }
     }

--- a/src/main/kotlin/dartzee/screen/game/GameStatisticsPanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/GameStatisticsPanel.kt
@@ -15,8 +15,6 @@ import java.awt.Color
 import java.awt.Component
 import java.awt.Font
 import java.sql.SQLException
-import java.util.*
-import java.util.stream.IntStream
 import javax.swing.*
 import javax.swing.border.EmptyBorder
 import javax.swing.border.MatteBorder
@@ -180,9 +178,7 @@ abstract class GameStatisticsPanel : JPanel()
                 row[i + 1] = "N/A"
             } else
             {
-                val scores = playerPts.stream().mapToInt { pt -> pt.finalScore }
-                val avg = scores.average().asDouble
-
+                val avg = playerPts.map { pt -> pt.finalScore }.average()
                 row[i + 1] = MathsUtil.round(avg, 2)
             }
         }
@@ -240,7 +236,7 @@ abstract class GameStatisticsPanel : JPanel()
         return row
     }
 
-    protected fun getBestGameRow(fn: (s: IntStream) -> OptionalInt): Array<Any?>
+    protected fun getBestGameRow(fn: (s: List<Int>) -> Int): Array<Any?>
     {
         val row = arrayOfNulls<Any>(getRowWidth())
         row[0] = "Best Game"
@@ -256,8 +252,8 @@ abstract class GameStatisticsPanel : JPanel()
             }
             else
             {
-                val scores = playerPts.stream().mapToInt { pt -> pt.finalScore }
-                row[i + 1] = fn.invoke(scores).asInt
+                val scores = playerPts.map { pt -> pt.finalScore }
+                row[i + 1] = fn.invoke(scores)
             }
 
         }
@@ -434,8 +430,7 @@ abstract class GameStatisticsPanel : JPanel()
 
         private fun getHistogramSum(tm: TableModel, col: Int): Long
         {
-            return getHistogramRowNumbers().stream()
-                    .mapToLong { row -> (tm.getValueAt(row, col) as Number).toLong() }
+            return getHistogramRowNumbers().map { row -> (tm.getValueAt(row, col) as Number).toLong() }
                     .sum()
         }
     }

--- a/src/main/kotlin/dartzee/screen/game/GameStatisticsPanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/GameStatisticsPanel.kt
@@ -35,7 +35,7 @@ abstract class GameStatisticsPanel : JPanel()
 {
     protected var playerNamesOrdered = mutableListOf<String>()
     protected var participants: List<ParticipantEntity>? = null
-    protected var hmPlayerToDarts = HashMapList<String, MutableList<Dart>>()
+    protected val hmPlayerToDarts = HashMapList<String, MutableList<Dart>>()
     var gameParams: String? = null
 
     private var tm = DefaultTableModel()
@@ -82,7 +82,7 @@ abstract class GameStatisticsPanel : JPanel()
     {
         this.participants = participants
 
-        hmPlayerToDarts = HashMapList()
+        hmPlayerToDarts.clear()
 
         for (participant in participants)
         {
@@ -156,8 +156,7 @@ abstract class GameStatisticsPanel : JPanel()
     private fun isSufficientData(): Boolean
     {
         val playerNames = hmPlayerToDarts.keys
-
-        return playerNames.stream().allMatch { p -> !getFlattenedDarts(p).isEmpty() }
+        return playerNames.all { p -> getFlattenedDarts(p).isNotEmpty() }
     }
 
     protected fun getRowWidth(): Int

--- a/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelRoundTheClock.kt
@@ -2,23 +2,21 @@ package dartzee.screen.game
 
 import dartzee.`object`.Dart
 import dartzee.core.util.MathsUtil
+import dartzee.core.util.maxOrZero
+import dartzee.core.util.minOrZero
 import dartzee.utils.getLongestStreak
 
 open class GameStatisticsPanelRoundTheClock : GameStatisticsPanel()
 {
     override fun addRowsToTable()
     {
-        addRow(getDartsPerNumber("Most darts", true) { getMaxDartsForAnyRound(it) })
+        addRow(getDartsPerNumber("Most darts", true) { it.maxOrZero() })
         addRow(getDartsPerNumber("Avg. darts", false) { getAverageDartsForAnyRound(it) })
-        addRow(getDartsPerNumber("Fewest darts", false) { getMinDartsForAnyRound(it) })
-
-        //addRow(arrayOfNulls(getRowWidth()))
+        addRow(getDartsPerNumber("Fewest darts", false) { it.minOrZero() })
 
         addRow(getLongestStreak())
         addRow(getBruceys("Brucey chances", false))
         addRow(getBruceys("Bruceys executed", true))
-
-        //addRow(arrayOfNulls(getRowWidth()))
 
         addRow(getDartsPerNumber(1, 1, "1"))
         addRow(getDartsPerNumber(2, 3))
@@ -45,11 +43,6 @@ open class GameStatisticsPanelRoundTheClock : GameStatisticsPanel()
         return row
     }
 
-    private fun getMaxDartsForAnyRound(darts: List<Int>): Any
-    {
-        return darts.max() ?: 0
-    }
-
     private fun getAverageDartsForAnyRound(darts: List<Int>): Any
     {
         val oi = darts.average()
@@ -60,8 +53,6 @@ open class GameStatisticsPanelRoundTheClock : GameStatisticsPanel()
 
     }
 
-    private fun getMinDartsForAnyRound(darts: List<Int>) = darts.min() ?: "N/A"
-
     private fun getBruceys(desc: String, enforceSuccess: Boolean): Array<Any?>
     {
         val row = factoryRow(desc)
@@ -70,11 +61,11 @@ open class GameStatisticsPanelRoundTheClock : GameStatisticsPanel()
             val playerName = playerNamesOrdered[i]
 
             val rounds = hmPlayerToDarts[playerName]!!
-            var bruceyRounds = rounds.filter { r -> r.size == 4 }
+            var bruceyRounds = rounds.filter { it.size == 4 }
 
             if (enforceSuccess)
             {
-                bruceyRounds = bruceyRounds.filter { r -> r.last().hitClockTarget(gameParams) }
+                bruceyRounds = bruceyRounds.filter { it.last().hitClockTarget(gameParams) }
             }
 
             row[i + 1] = bruceyRounds.size
@@ -91,9 +82,7 @@ open class GameStatisticsPanelRoundTheClock : GameStatisticsPanel()
             val playerName = playerNamesOrdered[i]
 
             val dartsGrouped = getDartsGroupedByParticipantAndNumber(playerName)
-            row[i + 1] = dartsGrouped.map { g -> g.size }
-                    .filter { it in min..max }
-                    .count()
+            row[i + 1] = dartsGrouped.filter { it.size in min..max }.size
         }
 
         return row
@@ -109,10 +98,10 @@ open class GameStatisticsPanelRoundTheClock : GameStatisticsPanel()
             var dartsGrouped = getDartsGroupedByParticipantAndNumber(playerName)
             if (!includeUnfinished)
             {
-                dartsGrouped = dartsGrouped.filter { g -> g.last().hitClockTarget(gameParams) }.toMutableList()
+                dartsGrouped = dartsGrouped.filter { it.last().hitClockTarget(gameParams) }.toMutableList()
             }
 
-            val sizes = dartsGrouped.map { g -> g.size }
+            val sizes = dartsGrouped.map { it.size }
             row[i + 1] = fn.invoke(sizes)
         }
 

--- a/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelX01.kt
@@ -10,7 +10,6 @@ import dartzee.utils.sumScore
 import java.awt.BorderLayout
 import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
-import java.util.stream.IntStream
 import javax.swing.JLabel
 import javax.swing.JPanel
 
@@ -40,9 +39,9 @@ open class GameStatisticsPanelX01 : GameStatisticsPanel(), PropertyChangeListene
         nfSetupThreshold.setMinimum(62)
         nfSetupThreshold.setMaximum(Integer.parseInt(gameParams) - 1)
 
-        addRow(getScoreRow({i -> i.max().asInt}, "Highest Score"))
+        addRow(getScoreRow("Highest Score") { it.max() ?: 0 })
         addRow(getThreeDartAvgsRow())
-        addRow(getScoreRow({i -> i.min().asInt}, "Lowest Score"))
+        addRow(getScoreRow("Lowest Score") { it.min() ?: 0 })
         addRow(getMultiplePercent("Miss %", 0))
         addRow(getMultiplePercent("Treble %", 3))
 
@@ -91,7 +90,7 @@ open class GameStatisticsPanelX01 : GameStatisticsPanel(), PropertyChangeListene
             parseTopDartEntry(sortedEntries, fifthDarts, i, darts.size)
 
             //Deal with the remainder
-            val remainder = sortedEntries.stream().mapToInt{e -> e.value.size}.sum().toDouble()
+            val remainder = sortedEntries.map { it.value.size }.sum().toDouble()
             val percent = MathsUtil.round(100*remainder / darts.size, 1)
             remainingDarts[i+1] = "$percent%"
         }
@@ -196,7 +195,7 @@ open class GameStatisticsPanelX01 : GameStatisticsPanel(), PropertyChangeListene
         return row
     }
 
-    private fun getScoreRow(f: (i: IntStream) -> Int, desc: String): Array<Any?>
+    private fun getScoreRow(desc: String, f: (i: List<Int>) -> Int): Array<Any?>
     {
         val row = arrayOfNulls<Any>(getRowWidth())
         row[0] = desc
@@ -206,11 +205,12 @@ open class GameStatisticsPanelX01 : GameStatisticsPanel(), PropertyChangeListene
             val playerName = playerNamesOrdered[i]
             val rounds = getScoringRounds(playerName)
 
-            if (!rounds.isEmpty())
+            if (rounds.isNotEmpty())
             {
-                val roundsAsTotal = rounds.stream().mapToInt { rnd -> sumScore(rnd) }
+                val roundsAsTotal = rounds.map { rnd -> sumScore(rnd) }
                 row[i + 1] = f.invoke(roundsAsTotal)
-            } else
+            }
+            else
             {
                 row[i + 1] = "N/A"
             }

--- a/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelX01.kt
@@ -3,6 +3,8 @@ package dartzee.screen.game
 import dartzee.`object`.Dart
 import dartzee.core.bean.NumberField
 import dartzee.core.util.MathsUtil
+import dartzee.core.util.maxOrZero
+import dartzee.core.util.minOrZero
 import dartzee.utils.calculateThreeDartAverage
 import dartzee.utils.getScoringDarts
 import dartzee.utils.isCheckoutDart
@@ -39,9 +41,9 @@ open class GameStatisticsPanelX01 : GameStatisticsPanel(), PropertyChangeListene
         nfSetupThreshold.setMinimum(62)
         nfSetupThreshold.setMaximum(Integer.parseInt(gameParams) - 1)
 
-        addRow(getScoreRow("Highest Score") { it.max() ?: 0 })
+        addRow(getScoreRow("Highest Score") { it.maxOrZero() })
         addRow(getThreeDartAvgsRow())
-        addRow(getScoreRow("Lowest Score") { it.min() ?: 0 })
+        addRow(getScoreRow("Lowest Score") { it.minOrZero() })
         addRow(getMultiplePercent("Miss %", 0))
         addRow(getMultiplePercent("Treble %", 3))
 
@@ -244,7 +246,7 @@ open class GameStatisticsPanelX01 : GameStatisticsPanel(), PropertyChangeListene
         val rounds = hmPlayerToDarts[playerName]
         rounds ?: return mutableListOf()
 
-        return rounds.filter{ r -> r.last().startingScore > nfSetupThreshold.getNumber() }.toList()
+        return rounds.filter { it.last().startingScore > nfSetupThreshold.getNumber() }.toList()
     }
 
     private fun getScoringDarts(playerName: String): MutableList<Dart>

--- a/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/GameStatisticsPanelX01.kt
@@ -239,12 +239,12 @@ open class GameStatisticsPanelX01 : GameStatisticsPanel(), PropertyChangeListene
         return row
     }
 
-    private fun getScoringRounds(playerName: String): MutableList<MutableList<Dart>>
+    private fun getScoringRounds(playerName: String): List<List<Dart>>
     {
         val rounds = hmPlayerToDarts[playerName]
         rounds ?: return mutableListOf()
 
-        return rounds.filter{r -> r.last().startingScore > nfSetupThreshold.getNumber()}.toMutableList()
+        return rounds.filter{ r -> r.last().startingScore > nfSetupThreshold.getNumber() }.toList()
     }
 
     private fun getScoringDarts(playerName: String): MutableList<Dart>

--- a/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelGolf.kt
@@ -1,14 +1,14 @@
 package dartzee.screen.game
 
+import dartzee.core.util.minOrZero
+
 class MatchStatisticsPanelGolf : GameStatisticsPanelGolf()
 {
     override fun addRowsToTable()
     {
         super.addRowsToTable()
 
-        //addRow(arrayOfNulls(getRowWidth()))
-
-        addRow(getBestGameRow { s -> s.min() })
+        addRow(getBestGameRow { s -> s.minOrZero() })
         addRow(getAverageGameRow())
     }
 

--- a/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelGolf.kt
@@ -8,7 +8,7 @@ class MatchStatisticsPanelGolf : GameStatisticsPanelGolf()
     {
         super.addRowsToTable()
 
-        addRow(getBestGameRow { s -> s.minOrZero() })
+        addRow(getBestGameRow { it.minOrZero() })
         addRow(getAverageGameRow())
     }
 

--- a/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelRoundTheClock.kt
@@ -1,5 +1,7 @@
 package dartzee.screen.game
 
+import dartzee.core.util.minOrZero
+
 class MatchStatisticsPanelRoundTheClock : GameStatisticsPanelRoundTheClock()
 {
     override fun addRowsToTable()
@@ -7,7 +9,7 @@ class MatchStatisticsPanelRoundTheClock : GameStatisticsPanelRoundTheClock()
         super.addRowsToTable()
 
         //addRow(arrayOfNulls(getRowWidth()))
-        addRow(getBestGameRow { stream -> stream.min() })
+        addRow(getBestGameRow { stream -> stream.minOrZero() })
         addRow(getAverageGameRow())
     }
 

--- a/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelRoundTheClock.kt
@@ -8,8 +8,7 @@ class MatchStatisticsPanelRoundTheClock : GameStatisticsPanelRoundTheClock()
     {
         super.addRowsToTable()
 
-        //addRow(arrayOfNulls(getRowWidth()))
-        addRow(getBestGameRow { stream -> stream.minOrZero() })
+        addRow(getBestGameRow { it.minOrZero() })
         addRow(getAverageGameRow())
     }
 

--- a/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelX01.kt
@@ -1,5 +1,6 @@
 package dartzee.screen.game
 
+import dartzee.core.util.minOrZero
 import dartzee.utils.isFinishRound
 import dartzee.utils.sumScore
 
@@ -11,9 +12,7 @@ class MatchStatisticsPanelX01 : GameStatisticsPanelX01()
 
         addRow(getHighestFinishRow())
 
-        //addRow(arrayOfNulls(getRowWidth()))
-
-        addRow(getBestGameRow { s -> s.min() })
+        addRow(getBestGameRow { s -> s.minOrZero() })
         addRow(getAverageGameRow())
     }
 
@@ -28,17 +27,7 @@ class MatchStatisticsPanelX01 : GameStatisticsPanelX01()
             val rounds = hmPlayerToDarts[playerName]!!
 
             val finishRounds = rounds.filter { r -> isFinishRound(r) }
-            if (finishRounds.isEmpty())
-            {
-                row[i + 1] = "N/A"
-            }
-            else
-            {
-                val stream = finishRounds.stream().mapToInt { r -> sumScore(r) }
-                val max = stream.max().asInt
-
-                row[i + 1] = max
-            }
+            row[i + 1] = finishRounds.map { r -> sumScore(r) }.max() ?: "N/A"
         }
 
         return row

--- a/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchStatisticsPanelX01.kt
@@ -12,7 +12,7 @@ class MatchStatisticsPanelX01 : GameStatisticsPanelX01()
 
         addRow(getHighestFinishRow())
 
-        addRow(getBestGameRow { s -> s.minOrZero() })
+        addRow(getBestGameRow { it.minOrZero() })
         addRow(getAverageGameRow())
     }
 

--- a/src/main/kotlin/dartzee/screen/game/MatchSummaryPanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchSummaryPanel.kt
@@ -13,11 +13,10 @@ import javax.swing.JPanel
 /**
  * The first tab displayed for any match. Provides a summary of the players' overall scores with (hopefully) nice graphs and stuff
  */
-class MatchSummaryPanel : PanelWithScorers<MatchScorer>(), ActionListener
+class MatchSummaryPanel(val match: DartsMatchEntity) : PanelWithScorers<MatchScorer>(), ActionListener
 {
     private val hmPlayerIdToScorer = mutableMapOf<String, MatchScorer>()
-    private val participants = mutableListOf<ParticipantEntity>()
-    private var match: DartsMatchEntity? = null
+    private val gameTabs = mutableListOf<DartsGamePanel<*, *>>()
 
     private var statsPanel: GameStatisticsPanel? = null
     private val refreshPanel = JPanel()
@@ -32,10 +31,8 @@ class MatchSummaryPanel : PanelWithScorers<MatchScorer>(), ActionListener
         btnRefresh.toolTipText = "Refresh stats"
     }
 
-    fun init(match: DartsMatchEntity, playersInStartingOrder: MutableList<PlayerEntity>)
+    fun init(playersInStartingOrder: List<PlayerEntity>)
     {
-        this.match = match
-
         val statsPanel = factoryStatsPanel()
 
         if (statsPanel != null)
@@ -66,8 +63,6 @@ class MatchSummaryPanel : PanelWithScorers<MatchScorer>(), ActionListener
 
         val row = arrayOf(localId, participant, participant, participant)
         scorer.addRow(row)
-
-        participants.add(participant)
     }
 
     fun updateTotalScores()
@@ -83,29 +78,22 @@ class MatchSummaryPanel : PanelWithScorers<MatchScorer>(), ActionListener
 
     fun updateStats()
     {
-        if (statsPanel != null && btnRefresh.isEnabled)
-        {
-            btnRefresh.isEnabled = false
-
-            val participantsCopy = participants.toMutableList()
-            val updateRunnable = Runnable{
-                statsPanel!!.showStats(participantsCopy)
-                btnRefresh.isEnabled = true
-            }
-
-            Thread(updateRunnable).start()
+        statsPanel?.let { statsPanel ->
+            val states = gameTabs.map { it.getPlayerStates() }.flatten()
+            statsPanel.showStats(states)
         }
     }
 
-    override fun factoryScorer(): MatchScorer
+    override fun factoryScorer() = MatchScorer()
+
+    fun addGameTab(tab: DartsGamePanel<*, *>)
     {
-        return MatchScorer()
+        gameTabs.add(tab)
     }
 
     private fun factoryStatsPanel(): GameStatisticsPanel?
     {
-        val type = match!!.gameType
-        return when (type)
+        return when (match.gameType)
         {
             GAME_TYPE_X01 -> MatchStatisticsPanelX01()
             GAME_TYPE_GOLF -> MatchStatisticsPanelGolf()

--- a/src/main/kotlin/dartzee/screen/game/MatchSummaryPanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchSummaryPanel.kt
@@ -23,8 +23,6 @@ class MatchSummaryPanel : PanelWithScorers<MatchScorer>(), ActionListener
     private val refreshPanel = JPanel()
     private val btnRefresh = JButton()
 
-    //TODO - test me
-
     init
     {
         refreshPanel.add(btnRefresh)

--- a/src/main/kotlin/dartzee/utils/X01Util.kt
+++ b/src/main/kotlin/dartzee/utils/X01Util.kt
@@ -114,8 +114,8 @@ fun isShanghai(darts: MutableList<Dart>): Boolean
 {
     return darts.size == 3
       && sumScore(darts) == 120
-      && darts.stream().allMatch{it.score == 20}
-      && darts.stream().anyMatch {it.multiplier == 1}
+      && darts.all { it.score == 20 }
+      && darts.any { it.multiplier == 1 }
 }
 
 /**

--- a/src/main/kotlin/dartzee/utils/X01Util.kt
+++ b/src/main/kotlin/dartzee/utils/X01Util.kt
@@ -71,7 +71,7 @@ fun getCheckoutScores(): MutableList<Int>
 }
 fun getCheckoutSingles(): List<Int> = getCheckoutScores().map { it / 2 }
 
-fun isFinishRound(round: MutableList<Dart>): Boolean
+fun isFinishRound(round: List<Dart>): Boolean
 {
     val drt = round.last()
     return drt.isDouble() && drt.getTotal() == drt.startingScore

--- a/src/test/kotlin/dartzee/core/util/TestExtensionFunctions.kt
+++ b/src/test/kotlin/dartzee/core/util/TestExtensionFunctions.kt
@@ -122,4 +122,32 @@ class TestExtensionFunctions: AbstractTest()
         ascending.shouldContainExactly(1, 2, 3, 4, 5)
         descending.shouldContainExactly(5, 4, 3, 2, 1)
     }
+
+    @Test
+    fun `Should return hash map values sorted by key`()
+    {
+        val map = mutableMapOf<Int, String>()
+        map[1] = "First"
+        map[3] = "Third"
+        map[2] = "Second"
+        map[4] = "Fourth"
+
+        map.getSortedValues().shouldContainExactly("First", "Second", "Third", "Fourth")
+    }
+
+    @Test
+    fun `Should return 0 for an empty list, or minmax otherwise`()
+    {
+        val list = mutableListOf<Int>()
+
+        list.minOrZero() shouldBe 0
+        list.maxOrZero() shouldBe 0
+
+        list.add(1)
+        list.add(4)
+        list.add(7)
+
+        list.minOrZero() shouldBe 1
+        list.maxOrZero() shouldBe 7
+    }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/zGY9cH05

Gets rid of the ad-hoc SQL used for in-game stats by instead keeping track of all the darts thrown within `PlayerState`. Other changes off the back of this:

- Tidy up a bunch of `.stream()` references, left over from Java -> Kt conversion
- Remove `preLoad` concept - now loading a match will fully load all the games up front (needed this for match stats to make any sense, as it needs all the thrown darts across all games)
- Improve load performance by not rendering the dartboard for completed games