### PR TITLE
Ensure Darts can be separated by participant in match stats

### DIFF
--- a/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
+++ b/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
@@ -15,6 +15,7 @@ sealed class AbstractPlayerState<S: DartsScorer>
 
     fun addDarts(darts: List<Dart>)
     {
+        darts.forEach { it.participantId = pt.rowId }
         this.darts.add(darts.toList())
     }
 }

--- a/src/main/resources/ChangeLog
+++ b/src/main/resources/ChangeLog
@@ -5,6 +5,7 @@
 = Fix bug with layout of player selectors
 = Fix bug trying to launch a custom match of Dartzee
 = Fix points based matches to support 6 players
+= Fix bug with RTC stats being incorrectly aggregated for matches
 
 --------- v4.1.0 ---------
 

--- a/src/test/kotlin/dartzee/game/state/TestAbstractPlayerState.kt
+++ b/src/test/kotlin/dartzee/game/state/TestAbstractPlayerState.kt
@@ -5,6 +5,7 @@ import dartzee.helper.AbstractTest
 import dartzee.helper.insertParticipant
 import dartzee.screen.game.scorer.DartsScorer
 import io.kotlintest.matchers.collections.shouldContainExactly
+import io.kotlintest.shouldBe
 import io.mockk.mockk
 import org.junit.Test
 
@@ -20,5 +21,19 @@ class TestAbstractPlayerState: AbstractTest()
 
         darts.clear()
         state.darts.first().shouldContainExactly(Dart(20, 1))
+    }
+
+    @Test
+    fun `It should populate the darts with the ParticipantId`()
+    {
+        val pt = insertParticipant()
+        val state = DefaultPlayerState(pt, mockk<DartsScorer>())
+
+        val dart = Dart(20, 1)
+        dart.participantId shouldBe ""
+
+        state.addDarts(mutableListOf(dart))
+
+        dart.participantId shouldBe pt.rowId
     }
 }


### PR DESCRIPTION
Fixes https://trello.com/c/mQiCs0XC

We used to set `participantId` on the darts retrieved from the DB for player stats. Need to replicate that in the new in memory state.