### PR TITLE
Reporting - Ability to exclude games don't have human players

### DIFF
--- a/src/main/kotlin/dartzee/core/bean/ScrollTable.kt
+++ b/src/main/kotlin/dartzee/core/bean/ScrollTable.kt
@@ -30,7 +30,7 @@ open class ScrollTable : JPanel(), TableColumnModelListener,
             return isEditable(arg0, arg1)
         }
     }
-    private val lblRowCount = JLabel("<Row Count>")
+    val lblRowCount = JLabel("<Row Count>")
     private val panelRowCount = JPanel()
     private val tableFooter: JTable = object : JTable() {
         override fun isCellEditable(row: Int, column: Int): Boolean {

--- a/src/main/kotlin/dartzee/core/util/ComponentUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/ComponentUtil.kt
@@ -11,19 +11,35 @@ import javax.swing.event.ChangeListener
 /**
  * Recurses through all child components, returning an ArrayList of all children of the appropriate type
  */
-fun <T> getAllChildComponentsForType(parent: Container, desiredClazz: Class<T>): MutableList<T>
+inline fun <reified T> Container.getAllChildComponentsForType(): List<T>
 {
     val ret = mutableListOf<T>()
 
-    val components = parent.components
-    addComponents(ret, components, desiredClazz)
+    val components = components
+    addComponents(ret, components, T::class.java)
 
     return ret
+}
+fun <T> addComponents(ret: MutableList<T>, components: Array<Component>, desiredClazz: Class<T>)
+{
+    for (comp in components)
+    {
+        if (desiredClazz.isInstance(comp))
+        {
+            ret.add(comp as T)
+        }
+
+        if (comp is Container)
+        {
+            val subComponents = comp.components
+            addComponents(ret, subComponents, desiredClazz)
+        }
+    }
 }
 
 fun Container.addActionListenerToAllChildren(listener: ActionListener)
 {
-    val children = getAllChildComponentsForType(this, JComponent::class.java)
+    val children = getAllChildComponentsForType<JComponent>()
     children.forEach {
         if (it is JComboBox<*>)
         {
@@ -45,7 +61,7 @@ fun Container.addActionListenerToAllChildren(listener: ActionListener)
 
 fun Container.addChangeListenerToAllChildren(listener: ChangeListener)
 {
-    val children = getAllChildComponentsForType(this, JComponent::class.java)
+    val children = getAllChildComponentsForType<JComponent>()
     children.forEach {
         if (it is JSpinner)
         {
@@ -59,31 +75,14 @@ fun Container.addChangeListenerToAllChildren(listener: ChangeListener)
 
 fun Container.enableChildren(enable: Boolean)
 {
-    getAllChildComponentsForType(this, Component::class.java).forEach{
+    getAllChildComponentsForType<Component>().forEach{
         it.isEnabled = enable
     }
 }
 
-private fun <T> addComponents(ret: MutableList<T>, components: Array<Component>, desiredClazz: Class<T>)
+fun Container.containsComponent(component: Component): Boolean
 {
-    for (comp in components)
-    {
-        if (desiredClazz.isInstance(comp))
-        {
-            ret.add(comp as T)
-        }
-
-        if (comp is Container)
-        {
-            val subComponents = comp.components
-            addComponents(ret, subComponents, desiredClazz)
-        }
-    }
-}
-
-fun containsComponent(parent: Container, component: Component): Boolean
-{
-    val list = getAllChildComponentsForType(parent, Component::class.java)
+    val list = getAllChildComponentsForType<Component>()
     return list.contains(component)
 }
 

--- a/src/main/kotlin/dartzee/reporting/IncludedPlayerParameters.kt
+++ b/src/main/kotlin/dartzee/reporting/IncludedPlayerParameters.kt
@@ -2,12 +2,10 @@ package dartzee.reporting
 
 const val COMPARATOR_SCORE_UNSET = "is unset"
 
-class IncludedPlayerParameters
+data class IncludedPlayerParameters(var finishingPositions: List<Int> = listOf(),
+                                    var finalScoreComparator: String = "",
+                                    var finalScore: Int = -1)
 {
-    var finishingPositions = listOf<Int>()
-    var finalScoreComparator = ""
-    var finalScore = -1
-
     fun generateExtraWhereSql(alias: String): String
     {
         val sb = StringBuilder()

--- a/src/main/kotlin/dartzee/reporting/IncludedPlayerParameters.kt
+++ b/src/main/kotlin/dartzee/reporting/IncludedPlayerParameters.kt
@@ -9,7 +9,7 @@ data class IncludedPlayerParameters(var finishingPositions: List<Int> = listOf()
     fun generateExtraWhereSql(alias: String): String
     {
         val sb = StringBuilder()
-        if (!finishingPositions.isEmpty())
+        if (finishingPositions.isNotEmpty())
         {
             val finishingPositionsStr = finishingPositions.joinToString()
             sb.append(" AND $alias.FinishingPosition IN ($finishingPositionsStr)")

--- a/src/main/kotlin/dartzee/reporting/ReportParameters.kt
+++ b/src/main/kotlin/dartzee/reporting/ReportParameters.kt
@@ -1,8 +1,8 @@
 package dartzee.reporting
 
 import dartzee.core.util.getEndOfTimeSqlString
-import dartzee.game.GameType
 import dartzee.db.PlayerEntity
+import dartzee.game.GameType
 import java.sql.Timestamp
 import java.util.*
 
@@ -15,9 +15,10 @@ class ReportParameters
     var dtStartTo: Timestamp? = null
     var dtFinishFrom: Timestamp? = null
     var dtFinishTo: Timestamp? = null
-    var hmIncludedPlayerToParms = mutableMapOf<PlayerEntity, IncludedPlayerParameters>()
+    var hmIncludedPlayerToParms = mapOf<PlayerEntity, IncludedPlayerParameters>()
     var excludedPlayers: List<PlayerEntity> = ArrayList()
-    private var partOfMatch = MATCH_FILTER_BOTH
+    var excludeOnlyAi: Boolean = false
+    private var partOfMatch = MatchFilter.BOTH
 
     fun getExtraWhereSql(): String
     {
@@ -67,11 +68,11 @@ class ReportParameters
             sb.append(getEndOfTimeSqlString())
         }
 
-        if (partOfMatch == MATCH_FILTER_GAMES_ONLY)
+        if (partOfMatch == MatchFilter.GAMES_ONLY)
         {
             sb.append(" AND g.DartsMatchId = ''")
         }
-        else if (partOfMatch == MATCH_FILTER_MATCHES_ONLY)
+        else if (partOfMatch == MatchFilter.MATCHES_ONLY)
         {
             sb.append(" AND g.DartsMatchId <> ''")
         }
@@ -102,6 +103,15 @@ class ReportParameters
             sb.append(" AND z.GameId = g.RowId)")
         }
 
+        if (excludeOnlyAi)
+        {
+            sb.append(" AND EXISTS (")
+            sb.append(" SELECT 1 FROM Participant z, Player p")
+            sb.append(" WHERE z.PlayerId = p.RowId")
+            sb.append(" AND z.GameId = g.RowId")
+            sb.append(" AND p.Strategy = -1)")
+        }
+
         return sb.toString()
     }
 
@@ -112,13 +122,13 @@ class ReportParameters
 
     fun setEnforceMatch(matches: Boolean)
     {
-        partOfMatch = if (matches) MATCH_FILTER_MATCHES_ONLY else MATCH_FILTER_GAMES_ONLY
+        partOfMatch = if (matches) MatchFilter.MATCHES_ONLY else MatchFilter.GAMES_ONLY
     }
+}
 
-    companion object
-    {
-        private const val MATCH_FILTER_MATCHES_ONLY = 0
-        private const val MATCH_FILTER_GAMES_ONLY = 1
-        private const val MATCH_FILTER_BOTH = 2
-    }
+private enum class MatchFilter
+{
+    MATCHES_ONLY,
+    GAMES_ONLY,
+    BOTH
 }

--- a/src/main/kotlin/dartzee/screen/MenuScreen.kt
+++ b/src/main/kotlin/dartzee/screen/MenuScreen.kt
@@ -1,6 +1,6 @@
 package dartzee.screen
 
-import dartzee.core.util.getAllChildComponentsForType
+import dartzee.core.util.addActionListenerToAllChildren
 import dartzee.screen.reporting.ReportingSetupScreen
 import dartzee.screen.stats.overall.LeaderboardsScreen
 import java.awt.BorderLayout
@@ -59,11 +59,7 @@ class MenuScreen : EmbeddedScreen()
         panel.add(menuDartboard)
 
         //Add ActionListeners
-        val buttons = getAllChildComponentsForType(this, AbstractButton::class.java)
-        for (button in buttons)
-        {
-            button.addActionListener(this)
-        }
+        addActionListenerToAllChildren(this)
     }
 
     override fun getScreenName(): String

--- a/src/main/kotlin/dartzee/screen/PlayerImageDialog.kt
+++ b/src/main/kotlin/dartzee/screen/PlayerImageDialog.kt
@@ -101,7 +101,7 @@ class PlayerImageDialog : SimpleDialog(), IFileUploadListener
     {
         val panel = tabbedPane.selectedComponent as JPanel
 
-        val radios = getAllChildComponentsForType(panel, PlayerImageRadio::class.java)
+        val radios = panel.getAllChildComponentsForType<PlayerImageRadio>()
         return radios.find { it.isSelected() } ?.playerImageId
     }
 

--- a/src/main/kotlin/dartzee/screen/PlayerSelectDialog.kt
+++ b/src/main/kotlin/dartzee/screen/PlayerSelectDialog.kt
@@ -3,15 +3,17 @@ package dartzee.screen
 import dartzee.bean.PlayerTypeFilterPanel
 import dartzee.bean.getSelectedPlayers
 import dartzee.bean.initPlayerTableModel
+import dartzee.core.bean.IDoubleClickListener
 import dartzee.core.bean.ScrollTable
 import dartzee.core.screen.SimpleDialog
 import dartzee.core.util.DialogUtil
 import dartzee.db.PlayerEntity
 import java.awt.BorderLayout
+import java.awt.Component
 import java.awt.event.ActionEvent
 import javax.swing.ListSelectionModel
 
-class PlayerSelectDialog(selectionMode: Int) : SimpleDialog()
+class PlayerSelectDialog(selectionMode: Int) : SimpleDialog(), IDoubleClickListener
 {
     var selectedPlayers = listOf<PlayerEntity>()
     var playersToExclude = listOf<PlayerEntity>()
@@ -28,6 +30,7 @@ class PlayerSelectDialog(selectionMode: Int) : SimpleDialog()
         contentPane.add(panelNorth, BorderLayout.NORTH)
         contentPane.add(tablePlayers, BorderLayout.CENTER)
         tablePlayers.setSelectionMode(selectionMode)
+        tablePlayers.addDoubleClickListener(this)
 
         panelNorth.addActionListener(this)
     }
@@ -42,6 +45,11 @@ class PlayerSelectDialog(selectionMode: Int) : SimpleDialog()
         {
             super.actionPerformed(arg0)
         }
+    }
+
+    override fun doubleClicked(source: Component)
+    {
+        okPressed()
     }
 
     fun buildTable()

--- a/src/main/kotlin/dartzee/screen/UtilitiesScreen.kt
+++ b/src/main/kotlin/dartzee/screen/UtilitiesScreen.kt
@@ -43,7 +43,7 @@ class UtilitiesScreen : EmbeddedScreen()
         panel.add(btnAchievementConversion, "cell 0 11,alignx center")
         panel.add(btnDartzeeTemplates, "cell 0 13, alignx center")
 
-        val buttons = getAllChildComponentsForType(panel, AbstractButton::class.java)
+        val buttons = panel.getAllChildComponentsForType<AbstractButton>()
         for (button in buttons)
         {
             button.font = Font("Tahoma", Font.PLAIN, 18)

--- a/src/main/kotlin/dartzee/screen/preference/PreferencesDialog.kt
+++ b/src/main/kotlin/dartzee/screen/preference/PreferencesDialog.kt
@@ -93,7 +93,7 @@ class PreferencesDialog : JDialog(), ActionListener
         selectedTab.refresh(true)
     }
 
-    private fun getPreferencePanels() = getAllChildComponentsForType(this, AbstractPreferencesPanel::class.java)
+    private fun getPreferencePanels() = getAllChildComponentsForType<AbstractPreferencesPanel>()
 
     override fun actionPerformed(arg0: ActionEvent)
     {

--- a/src/main/kotlin/dartzee/screen/preference/PreferencesPanelScorer.kt
+++ b/src/main/kotlin/dartzee/screen/preference/PreferencesPanelScorer.kt
@@ -129,7 +129,7 @@ class PreferencesPanelScorer : AbstractPreferencesPanel(), ChangeListener
         val fgBrightness = spinnerFgBrightness.value as Double
         val bgBrightness = spinnerBgBrightness.value as Double
 
-        val scoreLabels = getAllChildComponentsForType(panelScorerPreview, JLabel::class.java)
+        val scoreLabels = panelScorerPreview.getAllChildComponentsForType<JLabel>()
         for (i in scoreLabels.indices)
         {
             val scoreLabel = scoreLabels[i]

--- a/src/main/kotlin/dartzee/screen/reporting/PlayerParametersPanel.kt
+++ b/src/main/kotlin/dartzee/screen/reporting/PlayerParametersPanel.kt
@@ -16,10 +16,10 @@ import javax.swing.SpinnerNumberModel
 
 class PlayerParametersPanel : JPanel(), ActionListener
 {
-    private val chckbxFinalScore = JCheckBox("Game Score")
+    val chckbxFinalScore = JCheckBox("Game Score")
     private val comboBox = ComboBoxNumberComparison()
     private val spinner = JSpinner(SpinnerNumberModel(3, 3, 200, 1))
-    private val chckbxPosition = JCheckBox("Position")
+    val chckbxPosition = JCheckBox("Position")
     private val cbFirst = JCheckBox("1st")
     private val cbSecond = JCheckBox("2nd")
     private val cbThird = JCheckBox("3rd")
@@ -54,7 +54,7 @@ class PlayerParametersPanel : JPanel(), ActionListener
     {
         if (chckbxPosition.isSelected && getFinishingPositions().isEmpty())
         {
-            DialogUtil.showError("You must select at least one finishing position for Player " + player.name)
+            DialogUtil.showError("You must select at least one finishing position for player " + player.name)
             return false
         }
 

--- a/src/main/kotlin/dartzee/screen/reporting/PlayerParametersPanel.kt
+++ b/src/main/kotlin/dartzee/screen/reporting/PlayerParametersPanel.kt
@@ -26,7 +26,6 @@ class PlayerParametersPanel : JPanel(), ActionListener
 
     init
     {
-
         layout = MigLayout("", "[][][]", "[][]")
 
         comboBox.addOption(COMPARATOR_SCORE_UNSET)

--- a/src/main/kotlin/dartzee/screen/reporting/PlayerParametersPanel.kt
+++ b/src/main/kotlin/dartzee/screen/reporting/PlayerParametersPanel.kt
@@ -1,8 +1,9 @@
 package dartzee.screen.reporting
 
 import dartzee.core.bean.ComboBoxNumberComparison
-import dartzee.core.util.Debug
 import dartzee.core.util.DialogUtil
+import dartzee.core.util.StringUtil
+import dartzee.db.MAX_PLAYERS
 import dartzee.db.PlayerEntity
 import dartzee.reporting.COMPARATOR_SCORE_UNSET
 import dartzee.reporting.IncludedPlayerParameters
@@ -17,14 +18,11 @@ import javax.swing.SpinnerNumberModel
 class PlayerParametersPanel : JPanel(), ActionListener
 {
     val chckbxFinalScore = JCheckBox("Game Score")
-    private val comboBox = ComboBoxNumberComparison()
-    private val spinner = JSpinner(SpinnerNumberModel(3, 3, 200, 1))
+    val comboBox = ComboBoxNumberComparison()
+    val spinner = JSpinner(SpinnerNumberModel(3, 3, 200, 1))
     val chckbxPosition = JCheckBox("Position")
-    private val cbFirst = JCheckBox("1st")
-    private val cbSecond = JCheckBox("2nd")
-    private val cbThird = JCheckBox("3rd")
-    private val cbFourth = JCheckBox("4th")
-    private val cbUndecided = JCheckBox("Undecided")
+    val positionCheckboxes = List(MAX_PLAYERS) { ix -> JCheckBox(StringUtil.convertOrdinalToText(ix + 1)) }
+    val cbUndecided = JCheckBox("Undecided")
 
     init
     {
@@ -36,10 +34,7 @@ class PlayerParametersPanel : JPanel(), ActionListener
         add(chckbxFinalScore, "cell 0 0")
         add(comboBox, "width 80:80:80, cell 1 0,growx")
         add(chckbxPosition, "cell 0 1")
-        add(cbFirst, "flowx,cell 1 1")
-        add(cbSecond, "cell 1 1")
-        add(cbThird, "cell 1 1")
-        add(cbFourth, "cell 1 1")
+        positionCheckboxes.forEach { add(it, "cell 1 1") }
         add(cbUndecided, "cell 1 1")
         add(spinner, "cell 1 0")
 
@@ -87,12 +82,11 @@ class PlayerParametersPanel : JPanel(), ActionListener
     {
         val ret = mutableListOf<Int>()
 
-        addValueIfSelected(ret, cbFirst, 1)
-        addValueIfSelected(ret, cbSecond, 2)
-        addValueIfSelected(ret, cbThird, 3)
-        addValueIfSelected(ret, cbFourth, 4)
-        addValueIfSelected(ret, cbUndecided, -1)
+        positionCheckboxes.forEachIndexed { ix, cb ->
+            addValueIfSelected(ret, cb, ix + 1)
+        }
 
+        addValueIfSelected(ret, cbUndecided, -1)
         return ret
     }
 
@@ -106,11 +100,7 @@ class PlayerParametersPanel : JPanel(), ActionListener
 
     override fun actionPerformed(arg0: ActionEvent)
     {
-        return when (arg0.source)
-        {
-            chckbxFinalScore, chckbxPosition, comboBox -> updatePlayerOptionsEnabled()
-            else -> Debug.stackTrace("Unexpected actionPerformed: [${arg0.source}]")
-        }
+        updatePlayerOptionsEnabled()
     }
 
     fun disableAll()
@@ -125,21 +115,13 @@ class PlayerParametersPanel : JPanel(), ActionListener
 
     private fun updatePlayerOptionsEnabled()
     {
-        cbFirst.isEnabled = chckbxPosition.isSelected
-        cbSecond.isEnabled = chckbxPosition.isSelected
-        cbThird.isEnabled = chckbxPosition.isSelected
-        cbFourth.isEnabled = chckbxPosition.isSelected
-        cbUndecided.isEnabled = chckbxPosition.isSelected && !chckbxFinalScore.isSelected
+        positionCheckboxes.forEach { it.isEnabled = chckbxPosition.isSelected }
+        cbUndecided.isEnabled = chckbxPosition.isSelected
 
         comboBox.isEnabled = chckbxFinalScore.isSelected
 
         val comboSelection = comboBox.selectedItem as String
         val unset = comboSelection == COMPARATOR_SCORE_UNSET
         spinner.isEnabled = chckbxFinalScore.isSelected && !unset
-
-        if (chckbxFinalScore.isSelected)
-        {
-            cbUndecided.isSelected = false
-        }
     }
 }

--- a/src/main/kotlin/dartzee/screen/reporting/ReportingPlayersTab.kt
+++ b/src/main/kotlin/dartzee/screen/reporting/ReportingPlayersTab.kt
@@ -1,0 +1,167 @@
+package dartzee.screen.reporting
+
+import dartzee.bean.getSelectedPlayer
+import dartzee.bean.getSelectedPlayers
+import dartzee.bean.initPlayerTableModel
+import dartzee.core.bean.RadioButtonPanel
+import dartzee.core.bean.RowSelectionListener
+import dartzee.core.bean.ScrollTable
+import dartzee.core.util.DialogUtil
+import dartzee.db.PlayerEntity
+import dartzee.reporting.ReportParameters
+import dartzee.screen.PlayerSelectDialog
+import dartzee.screen.ScreenCache
+import net.miginfocom.swing.MigLayout
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.event.ActionEvent
+import java.awt.event.ActionListener
+import javax.swing.*
+
+class ReportingPlayersTab: JPanel(), ActionListener, RowSelectionListener
+{
+    private val hmPlayerToParametersPanel = mutableMapOf<PlayerEntity, PlayerParametersPanel>()
+
+    private val panelNorth = JPanel()
+    private val checkBoxExcludeOnlyAi = JCheckBox("Exclude games with only AI players")
+    private val lblIncludeMode = JLabel("Include games with:")
+    private val panelRdbtns = RadioButtonPanel()
+    private val rdbtnInclude = JRadioButton("All the selected players")
+    private val rdbtnExclude = JRadioButton("None of the selected players")
+    private val panelTable = JPanel()
+    private val panelTableButtons = JPanel()
+    private val scrollTable = ScrollTable()
+    private val btnAddPlayer = JButton("")
+    private val btnRemovePlayer = JButton("")
+
+    private var includedPlayerPanel = PlayerParametersPanel().also { it.disableAll() }
+
+    init
+    {
+        layout = BorderLayout(0, 0)
+
+        add(panelNorth, BorderLayout.NORTH)
+        panelNorth.layout = MigLayout("", "[]", "[][]")
+        panelNorth.add(checkBoxExcludeOnlyAi, "cell 0 0")
+        panelNorth.add(panelRdbtns, "cell 0 1")
+        panelRdbtns.add(lblIncludeMode)
+        panelRdbtns.add(rdbtnInclude)
+        panelRdbtns.add(rdbtnExclude)
+        panelTable.layout = BorderLayout(0, 0)
+        panelTable.add(panelTableButtons, BorderLayout.NORTH)
+        panelTable.add(scrollTable, BorderLayout.CENTER)
+        val flowLayout = panelTableButtons.layout as FlowLayout
+        flowLayout.alignment = FlowLayout.LEFT
+        btnAddPlayer.preferredSize = Dimension(30, 30)
+        btnAddPlayer.icon = ImageIcon(ReportingSetupScreen::class.java.getResource("/buttons/addPlayer.png"))
+        panelTableButtons.add(btnAddPlayer)
+        btnRemovePlayer.icon = ImageIcon(ReportingSetupScreen::class.java.getResource("/buttons/removePlayer.png"))
+        btnRemovePlayer.preferredSize = Dimension(30, 30)
+        panelTableButtons.add(btnRemovePlayer)
+        add(panelTable, BorderLayout.CENTER)
+        add(includedPlayerPanel, BorderLayout.SOUTH)
+
+        panelRdbtns.addActionListener(this)
+        btnAddPlayer.addActionListener(this)
+        btnRemovePlayer.addActionListener(this)
+        scrollTable.addRowSelectionListener(this)
+
+        scrollTable.setRowName("player")
+        scrollTable.initPlayerTableModel(emptyList())
+    }
+
+    override fun actionPerformed(e: ActionEvent?)
+    {
+        when (e?.source)
+        {
+            btnAddPlayer -> addPlayers()
+            btnRemovePlayer -> removePlayers()
+            rdbtnInclude, rdbtnExclude -> togglePlayerParameters()
+        }
+    }
+
+    private fun togglePlayerParameters()
+    {
+        if (rdbtnInclude.isSelected)
+        {
+            add(includedPlayerPanel, BorderLayout.SOUTH)
+        }
+        else
+        {
+            remove(includedPlayerPanel)
+        }
+
+        ScreenCache.mainScreen.pack()
+        repaint()
+    }
+
+    private fun addPlayers()
+    {
+        val allSelected = hmPlayerToParametersPanel.keys.toList()
+        val players = PlayerSelectDialog.selectPlayers(allSelected)
+        for (player in players)
+        {
+            hmPlayerToParametersPanel[player] = PlayerParametersPanel()
+        }
+
+        scrollTable.initPlayerTableModel(hmPlayerToParametersPanel.keys.toList())
+        scrollTable.selectFirstRow()
+    }
+
+    private fun removePlayers()
+    {
+        val playersToRemove = scrollTable.getSelectedPlayers()
+        if (playersToRemove.isEmpty())
+        {
+            DialogUtil.showError("You must select player(s) to remove.")
+            return
+        }
+
+        playersToRemove.forEach { hmPlayerToParametersPanel.remove(it) }
+        scrollTable.initPlayerTableModel(hmPlayerToParametersPanel.keys.toList())
+    }
+
+    override fun selectionChanged(src: ScrollTable)
+    {
+        remove(includedPlayerPanel)
+
+        val player = scrollTable.getSelectedPlayer()
+        if (player == null)
+        {
+            includedPlayerPanel = PlayerParametersPanel().also { it.disableAll() }
+        }
+        else
+        {
+            includedPlayerPanel = hmPlayerToParametersPanel[player]!!
+        }
+
+        if (rdbtnInclude.isSelected)
+        {
+            add(includedPlayerPanel, BorderLayout.SOUTH)
+        }
+
+        ScreenCache.mainScreen.pack()
+        repaint()
+    }
+
+    fun valid(): Boolean
+    {
+        val entries = hmPlayerToParametersPanel.entries
+        return entries.all { it.value.valid(it.key) }
+    }
+
+    fun populateReportParameters(rp: ReportParameters)
+    {
+        rp.excludeOnlyAi = checkBoxExcludeOnlyAi.isSelected
+
+        if (rdbtnInclude.isSelected)
+        {
+            rp.hmIncludedPlayerToParms = hmPlayerToParametersPanel.mapValues { entry -> entry.value.generateParameters() }
+        }
+        else
+        {
+            rp.excludedPlayers = hmPlayerToParametersPanel.keys.toList()
+        }
+    }
+}

--- a/src/main/kotlin/dartzee/screen/reporting/ReportingPlayersTab.kt
+++ b/src/main/kotlin/dartzee/screen/reporting/ReportingPlayersTab.kt
@@ -24,18 +24,18 @@ class ReportingPlayersTab: JPanel(), ActionListener, RowSelectionListener
     private val hmPlayerToParametersPanel = mutableMapOf<PlayerEntity, PlayerParametersPanel>()
 
     private val panelNorth = JPanel()
-    private val checkBoxExcludeOnlyAi = JCheckBox("Exclude games with only AI players")
+    val checkBoxExcludeOnlyAi = JCheckBox("Exclude games with only AI players")
     private val lblIncludeMode = JLabel("Include games with:")
     private val panelRdbtns = RadioButtonPanel()
-    private val rdbtnInclude = JRadioButton("All the selected players")
-    private val rdbtnExclude = JRadioButton("None of the selected players")
+    val rdbtnInclude = JRadioButton("All the selected players")
+    val rdbtnExclude = JRadioButton("None of the selected players")
     private val panelTable = JPanel()
     private val panelTableButtons = JPanel()
-    private val scrollTable = ScrollTable()
+    val scrollTable = ScrollTable()
     private val btnAddPlayer = JButton("")
-    private val btnRemovePlayer = JButton("")
+    val btnRemovePlayer = JButton("")
 
-    private var includedPlayerPanel = PlayerParametersPanel().also { it.disableAll() }
+    var includedPlayerPanel = PlayerParametersPanel().also { it.disableAll() }
 
     init
     {
@@ -100,6 +100,11 @@ class ReportingPlayersTab: JPanel(), ActionListener, RowSelectionListener
     {
         val allSelected = hmPlayerToParametersPanel.keys.toList()
         val players = PlayerSelectDialog.selectPlayers(allSelected)
+        addPlayers(players)
+    }
+
+    fun addPlayers(players: List<PlayerEntity>)
+    {
         for (player in players)
         {
             hmPlayerToParametersPanel[player] = PlayerParametersPanel()
@@ -147,8 +152,13 @@ class ReportingPlayersTab: JPanel(), ActionListener, RowSelectionListener
 
     fun valid(): Boolean
     {
-        val entries = hmPlayerToParametersPanel.entries
-        return entries.all { it.value.valid(it.key) }
+        if (rdbtnInclude.isSelected)
+        {
+            val entries = hmPlayerToParametersPanel.entries
+            return entries.all { it.value.valid(it.key) }
+        }
+
+        return true
     }
 
     fun populateReportParameters(rp: ReportParameters)

--- a/src/main/kotlin/dartzee/screen/stats/player/AbstractStatisticsTab.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/AbstractStatisticsTab.kt
@@ -40,7 +40,7 @@ abstract class AbstractStatisticsTab : JPanel(), PropertyChangeListener
             container.layout = GridLayout(0, 1, 0, 0)
             container.remove(otherComponent)
         }
-        else if (!containsComponent(container, otherComponent))
+        else if (!container.containsComponent(otherComponent))
         {
             container.layout = GridLayout(0, 2, 0, 0)
             container.add(otherComponent)

--- a/src/main/kotlin/dartzee/screen/stats/player/AbstractStatisticsTabPieBreakdown.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/AbstractStatisticsTabPieBreakdown.kt
@@ -135,7 +135,7 @@ abstract class AbstractStatisticsTabPieBreakdown : AbstractStatisticsTab(), RowS
             tablePanel.layout = GridLayout(1, 1, 0, 0)
             tablePanel.remove(tableHoleBreakdownOther)
         }
-        else if (!containsComponent(tablePanel, tableHoleBreakdownOther))
+        else if (!tablePanel.containsComponent(tableHoleBreakdownOther))
         {
             pieChartPanel.layout = GridLayout(2, 1, 0, 0)
             pieChartPanel.add(otherPieChartPanel)

--- a/src/main/kotlin/dartzee/screen/stats/player/MovingAverageChartPanel.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/MovingAverageChartPanel.kt
@@ -45,12 +45,12 @@ class MovingAverageChartPanel(private val parentTab: AbstractStatisticsTab) : JP
     private fun adjustTickboxes()
     {
         //Remove checkboxes that are no longer relevant (e.g. just removed a comparison)
-        getAllChildComponentsForType(panelCheckBoxes, JCheckBox::class.java).forEach {
+        panelCheckBoxes.getAllChildComponentsForType<JCheckBox>().forEach {
             if (getGraphSeriesIndexForCheckBox(it) == -1) panelCheckBoxes.remove(it)
         }
 
         //Go through what's left and add any others that are required by the graph (e.g. just added a comparison)
-        val checkBoxes = getAllChildComponentsForType(panelCheckBoxes, JCheckBox::class.java)
+        val checkBoxes = panelCheckBoxes.getAllChildComponentsForType<JCheckBox>()
         val allSeries: List<XYSeries> = graphCollection.getXYSeries()
         allSeries.forEach {
             val key = "${it.key}"

--- a/src/main/kotlin/dartzee/screen/stats/player/PlayerStatisticsFilterDialog.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/PlayerStatisticsFilterDialog.kt
@@ -22,7 +22,7 @@ class PlayerStatisticsFilterDialog(gameType: GameType): SimpleDialog(), ChangeLi
     private var gameParams = ""
     private var filterByDate = false
 
-    private var filterPanel:GameParamFilterPanel? = null
+    private val filterPanel: GameParamFilterPanel = getFilterPanel(gameType)
 
     private val cbType = JCheckBox("Type")
     private val panelGameType = JPanel()
@@ -32,8 +32,6 @@ class PlayerStatisticsFilterDialog(gameType: GameType): SimpleDialog(), ChangeLi
 
     init
     {
-        filterPanel = getFilterPanel(gameType)
-
         title = "Filters"
         setSize(473, 200)
         isModal = true
@@ -42,12 +40,9 @@ class PlayerStatisticsFilterDialog(gameType: GameType): SimpleDialog(), ChangeLi
         contentPane.add(panelFilters, BorderLayout.CENTER)
         panelFilters.layout = GridLayout(0, 1, 0, 0)
 
-        if (filterPanel != null)
-        {
-            panelFilters.add(panelGameType)
-            panelGameType.add(cbType)
-            panelGameType.add(filterPanel)
-        }
+        panelFilters.add(panelGameType)
+        panelGameType.add(cbType)
+        panelGameType.add(filterPanel)
 
         panelFilters.add(panelDate)
 
@@ -68,7 +63,7 @@ class PlayerStatisticsFilterDialog(gameType: GameType): SimpleDialog(), ChangeLi
         }
         else
         {
-            desc += filterPanel!!.getFilterDesc()
+            desc += filterPanel.getFilterDesc()
         }
 
         return desc
@@ -86,7 +81,7 @@ class PlayerStatisticsFilterDialog(gameType: GameType): SimpleDialog(), ChangeLi
     {
         if (cbType.isSelected)
         {
-            gameParams = filterPanel!!.getGameParams()
+            gameParams = filterPanel.getGameParams()
         }
         else
         {
@@ -99,11 +94,11 @@ class PlayerStatisticsFilterDialog(gameType: GameType): SimpleDialog(), ChangeLi
     fun refresh()
     {
         cbType.isSelected = !gameParams.isEmpty()
-        filterPanel!!.isEnabled = cbType.isSelected
+        filterPanel.isEnabled = cbType.isSelected
 
         if (!gameParams.isEmpty())
         {
-            filterPanel!!.setGameParams(gameParams)
+            filterPanel.setGameParams(gameParams)
         }
 
         chckbxDatePlayed.isSelected = filterByDate
@@ -153,7 +148,7 @@ class PlayerStatisticsFilterDialog(gameType: GameType): SimpleDialog(), ChangeLi
         val src = arg0.source as Component
         if (src === cbType)
         {
-            filterPanel!!.isEnabled = cbType.isSelected
+            filterPanel.isEnabled = cbType.isSelected
         }
         else if (src === chckbxDatePlayed)
         {

--- a/src/main/kotlin/dartzee/screen/stats/player/PlayerStatisticsScreen.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/PlayerStatisticsScreen.kt
@@ -228,7 +228,7 @@ class PlayerStatisticsScreen : EmbeddedScreen()
         filteredGamesOther = populateFilteredGames(hmLocalIdToWrapperOther, filterPanelOther)
 
         //Update the tabs
-        val tabs = getAllChildComponentsForType(this, AbstractStatisticsTab::class.java)
+        val tabs = getAllChildComponentsForType<AbstractStatisticsTab>()
         for (tab in tabs)
         {
             tab.setFilteredGames(filteredGames, filteredGamesOther)

--- a/src/main/kotlin/dartzee/screen/stats/player/x01/StatisticsTabFinishBreakdown.kt
+++ b/src/main/kotlin/dartzee/screen/stats/player/x01/StatisticsTabFinishBreakdown.kt
@@ -103,7 +103,7 @@ class StatisticsTabFinishBreakdown: AbstractStatisticsTab(), RowSelectionListene
             tablePanel.layout = GridLayout(1, 1, 0, 0)
             tablePanel.remove(tableFavouriteDoublesOther)
         }
-        else if (!containsComponent(tablePanel, tableFavouriteDoublesOther))
+        else if (!tablePanel.containsComponent(tableFavouriteDoublesOther))
         {
             tablePanel.layout = GridLayout(2, 1, 0, 0)
             tablePanel.add(tableFavouriteDoublesOther)

--- a/src/main/resources/ChangeLog
+++ b/src/main/resources/ChangeLog
@@ -1,5 +1,6 @@
 --------- v4.1.1 ---------
 
++ Ability to exclude "all AI" games from reporting. Clarified existing player options.
 = Fix bug with Optimal Scorecard rendering
 = Fix bug with the number of games in "First To" matches
 = Fix bug with layout of player selectors

--- a/src/test/kotlin/dartzee/TestUtils.kt
+++ b/src/test/kotlin/dartzee/TestUtils.kt
@@ -2,6 +2,7 @@ package dartzee
 
 import dartzee.`object`.*
 import dartzee.core.helper.makeMouseEvent
+import dartzee.core.util.getAllChildComponentsForType
 import dartzee.dartzee.DartzeeRuleDto
 import dartzee.logging.LogRecord
 import dartzee.logging.LoggingCode
@@ -13,8 +14,10 @@ import io.kotlintest.shouldBe
 import io.mockk.MockKMatcherScope
 import java.awt.Color
 import java.awt.Component
+import java.awt.Container
 import java.awt.Point
 import java.time.Instant
+import javax.swing.AbstractButton
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 
@@ -113,4 +116,22 @@ fun MockKMatcherScope.ruleDtosEq(players: List<DartzeeRuleDto>) = match<List<Dar
 fun LogRecord.shouldContainKeyValues(vararg values: Pair<String, Any?>)
 {
     keyValuePairs.shouldContainExactly(mapOf(*values))
+}
+
+inline fun <reified T: AbstractButton> Container.clickComponent(text: String)
+{
+
+    val allComponents = getAllChildComponentsForType<T>()
+    val matching = allComponents.filter { it.text == name }
+
+    if (matching.isEmpty())
+    {
+        throw Exception("No ${T::class.simpleName} found with text [$text]")
+    }
+    else if (matching.size > 1)
+    {
+        throw Exception("Non-unique text - ${matching.size} ${T::class.simpleName}s found with text [$text]")
+    }
+
+    matching.first().doClick()
 }

--- a/src/test/kotlin/dartzee/TestUtils.kt
+++ b/src/test/kotlin/dartzee/TestUtils.kt
@@ -118,11 +118,10 @@ fun LogRecord.shouldContainKeyValues(vararg values: Pair<String, Any?>)
     keyValuePairs.shouldContainExactly(mapOf(*values))
 }
 
-inline fun <reified T: AbstractButton> Container.clickComponent(text: String)
+inline fun <reified T: AbstractButton> Container.findComponent(text: String): T
 {
-
     val allComponents = getAllChildComponentsForType<T>()
-    val matching = allComponents.filter { it.text == name }
+    val matching = allComponents.filter { it.text == text }
 
     if (matching.isEmpty())
     {
@@ -133,5 +132,10 @@ inline fun <reified T: AbstractButton> Container.clickComponent(text: String)
         throw Exception("Non-unique text - ${matching.size} ${T::class.simpleName}s found with text [$text]")
     }
 
-    matching.first().doClick()
+    return matching.first()
+}
+
+inline fun <reified T: AbstractButton> Container.clickComponent(text: String)
+{
+    findComponent<T>(text).doClick()
 }

--- a/src/test/kotlin/dartzee/bean/TestPlayerSelector.kt
+++ b/src/test/kotlin/dartzee/bean/TestPlayerSelector.kt
@@ -182,7 +182,7 @@ class TestPlayerSelector: AbstractTest()
         selector.init()
 
         selector.tablePlayersToSelectFrom.selectRow(0)
-        doubleClick(selector.tablePlayersToSelectFrom)
+        selector.tablePlayersToSelectFrom.doubleClick()
         selector.getSelectedPlayers().size shouldBe 1
     }
 
@@ -195,7 +195,7 @@ class TestPlayerSelector: AbstractTest()
         selector.init(listOf(alex))
 
         selector.tablePlayersSelected.selectRow(0)
-        doubleClick(selector.tablePlayersSelected)
+        selector.tablePlayersSelected.doubleClick()
         selector.tablePlayersToSelectFrom.rowCount shouldBe 1
     }
 

--- a/src/test/kotlin/dartzee/core/bean/TestSwingExtensions.kt
+++ b/src/test/kotlin/dartzee/core/bean/TestSwingExtensions.kt
@@ -124,7 +124,7 @@ class TestSwingExtensions: AbstractTest()
 
         tf.layout.shouldBeInstanceOf<BorderLayout>()
 
-        val ghostText = getAllChildComponentsForType(tf, GhostText::class.java).first()
+        val ghostText = tf.getAllChildComponentsForType<GhostText>().first()
         ghostText.text shouldBe "Hello"
     }
 

--- a/src/test/kotlin/dartzee/core/helper/ComponentHelpers.kt
+++ b/src/test/kotlin/dartzee/core/helper/ComponentHelpers.kt
@@ -48,14 +48,14 @@ fun JComponent.processKeyPress(key: Int)
     action.actionPerformed(mockk(relaxed = true))
 }
 
-fun doubleClick(component: Component)
+fun Component.doubleClick()
 {
-    val mouseEvent = MouseEvent(component, MOUSE_CLICKED, System.currentTimeMillis(), -1,
+    val mouseEvent = MouseEvent(this, MOUSE_CLICKED, System.currentTimeMillis(), -1,
     0, 0, 2, false)
 
-    if (component is MouseListener)
+    if (this is MouseListener)
     {
-        component.mouseClicked(mouseEvent)
+        this.mouseClicked(mouseEvent)
     }
 }
 

--- a/src/test/kotlin/dartzee/core/screen/TestTableModelDialog.kt
+++ b/src/test/kotlin/dartzee/core/screen/TestTableModelDialog.kt
@@ -22,7 +22,7 @@ class TestTableModelDialog: AbstractTest()
         tmd.isModal shouldBe true
         tmd.allowCancel() shouldBe false
 
-        getAllChildComponentsForType(tmd, table.javaClass).shouldContainExactly(table)
+        tmd.getAllChildComponentsForType<ScrollTable>().shouldContainExactly(table)
     }
 
     @Test

--- a/src/test/kotlin/dartzee/core/util/TestComponentUtil.kt
+++ b/src/test/kotlin/dartzee/core/util/TestComponentUtil.kt
@@ -29,10 +29,10 @@ class TestComponentUtil: AbstractTest()
         panel.add(btn)
         panel.add(rdbtn)
 
-        getAllChildComponentsForType(panel, JButton::class.java).shouldContainExactly(btn)
-        getAllChildComponentsForType(panel, JRadioButton::class.java).shouldContainExactly(rdbtn)
-        getAllChildComponentsForType(panel, AbstractButton::class.java).shouldContainExactly(btn, rdbtn)
-        getAllChildComponentsForType(panel, JCheckBox::class.java).shouldBeEmpty()
+        panel.getAllChildComponentsForType<JButton>().shouldContainExactly(btn)
+        panel.getAllChildComponentsForType<JRadioButton>().shouldContainExactly(rdbtn)
+        panel.getAllChildComponentsForType<AbstractButton>().shouldContainExactly(btn, rdbtn)
+        panel.getAllChildComponentsForType<JCheckBox>().shouldBeEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class TestComponentUtil: AbstractTest()
         panel2.add(panel3)
         panel3.add(btn3)
 
-        getAllChildComponentsForType(panel, JButton::class.java).shouldContainExactly(btn1, btn2, btn3)
+        panel.getAllChildComponentsForType<JButton>().shouldContainExactly(btn1, btn2, btn3)
     }
 
     @Test
@@ -65,10 +65,10 @@ class TestComponentUtil: AbstractTest()
         panel.add(panel2)
         panel2.add(btnOne)
 
-        containsComponent(panel, btnOne) shouldBe true
-        containsComponent(panel2, btnOne) shouldBe true
+        panel.containsComponent(btnOne) shouldBe true
+        panel2.containsComponent(btnOne) shouldBe true
 
-        containsComponent(panel, JButton()) shouldBe false
+        panel.containsComponent(JButton()) shouldBe false
     }
 
     @Test

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -24,9 +24,9 @@ fun wipeTable(tableName: String)
 
 fun randomGuid() = UUID.randomUUID().toString()
 
-fun insertPlayerForGame(name: String, gameId: String): PlayerEntity
+fun insertPlayerForGame(name: String, gameId: String, strategy: Int = 1): PlayerEntity
 {
-    val player = insertPlayer(name = name)
+    val player = insertPlayer(name = name, strategy = strategy)
     insertParticipant(playerId = player.rowId, gameId = gameId)
     return player
 }

--- a/src/test/kotlin/dartzee/reporting/TestIncludedPlayerParameters.kt
+++ b/src/test/kotlin/dartzee/reporting/TestIncludedPlayerParameters.kt
@@ -37,7 +37,7 @@ class TestIncludedPlayerParameters: AbstractTest()
         ipp.finishingPositions = listOf(1, 3)
 
         val rp = ReportParameters()
-        rp.hmIncludedPlayerToParms[player] = ipp
+        rp.hmIncludedPlayerToParms = mapOf(player to ipp)
 
         val results = runReport(rp)
         results shouldHaveSize 2

--- a/src/test/kotlin/dartzee/reporting/TestIncludedPlayerParameters.kt
+++ b/src/test/kotlin/dartzee/reporting/TestIncludedPlayerParameters.kt
@@ -1,5 +1,6 @@
 package dartzee.reporting
 
+import dartzee.core.bean.ComboBoxNumberComparison
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertGame
 import dartzee.helper.insertParticipant
@@ -43,5 +44,44 @@ class TestIncludedPlayerParameters: AbstractTest()
         results shouldHaveSize 2
 
         results.map{ it.localId }.shouldContainExactlyInAnyOrder(1, 2)
+    }
+
+    @Test
+    fun `Should filter by final score`()
+    {
+        val rp = ReportParameters()
+        val player = insertPlayer("Bob")
+
+        val g40 = insertGame(localId = 1).rowId
+        val g30 = insertGame(localId = 2).rowId
+        val gUnfinished = insertGame(localId = 3).rowId
+        val g25 = insertGame(localId = 4).rowId
+
+        insertParticipant(playerId = player.rowId, finishingPosition = 1, finalScore = 40, gameId = g40)
+        insertParticipant(playerId = player.rowId, finishingPosition = 2, finalScore = 30, gameId = g30)
+        insertParticipant(playerId = player.rowId, finishingPosition = 3, finalScore = 25, gameId = g25)
+        insertParticipant(playerId = player.rowId, finishingPosition = -1, finalScore = -1, gameId = gUnfinished)
+
+        //Greater than 25
+        val ipp = IncludedPlayerParameters(finalScore = 25, finalScoreComparator = ComboBoxNumberComparison.FILTER_MODE_GREATER_THAN)
+        rp.hmIncludedPlayerToParms = mapOf(player to ipp)
+        var results = runReport(rp)
+        results.map { it.localId }.shouldContainExactlyInAnyOrder(1, 2)
+
+        //Equal to 25
+        ipp.finalScoreComparator = ComboBoxNumberComparison.FILTER_MODE_EQUAL_TO
+        results = runReport(rp)
+        results.map { it.localId }.shouldContainExactlyInAnyOrder(4)
+
+        //Undecided
+        ipp.finalScoreComparator = COMPARATOR_SCORE_UNSET
+        results = runReport(rp)
+        results.map { it.localId }.shouldContainExactlyInAnyOrder(3)
+
+        //Less than 31
+        ipp.finalScore = 31
+        ipp.finalScoreComparator = ComboBoxNumberComparison.FILTER_MODE_LESS_THAN
+        results = runReport(rp)
+        results.map { it.localId }.shouldContainExactlyInAnyOrder(2, 4)
     }
 }

--- a/src/test/kotlin/dartzee/reporting/TestReportParameters.kt
+++ b/src/test/kotlin/dartzee/reporting/TestReportParameters.kt
@@ -173,6 +173,43 @@ class TestReportParameters: AbstractTest()
     }
 
     @Test
+    fun `Should be able to only include games with the specified players`()
+    {
+        val gAllPlayers = insertGame()
+        val alice = insertPlayerForGame("Alice", gAllPlayers.rowId)
+        val bob = insertPlayerForGame("Bob", gAllPlayers.rowId)
+        val clive = insertPlayerForGame("Clive", gAllPlayers.rowId)
+        val daisy = insertPlayerForGame("Daisy", gAllPlayers.rowId)
+
+        val gAliceAndBob = insertGame()
+        insertParticipant(playerId = alice.rowId, gameId = gAliceAndBob.rowId)
+        insertParticipant(playerId = bob.rowId, gameId = gAliceAndBob.rowId)
+
+        val gAliceCliveDaisy = insertGame()
+        insertParticipant(playerId = alice.rowId, gameId = gAliceCliveDaisy.rowId)
+        insertParticipant(playerId = clive.rowId, gameId = gAliceCliveDaisy.rowId)
+        insertParticipant(playerId = daisy.rowId, gameId = gAliceCliveDaisy.rowId)
+
+        val gBobAndDaisy = insertGame()
+        insertParticipant(playerId = bob.rowId, gameId = gBobAndDaisy.rowId)
+        insertParticipant(playerId = daisy.rowId, gameId = gBobAndDaisy.rowId)
+
+        val gCliveDaisy = insertGame()
+        insertParticipant(playerId = clive.rowId, gameId = gCliveDaisy.rowId)
+        insertParticipant(playerId = daisy.rowId, gameId = gCliveDaisy.rowId)
+
+        val rpIncludeAlice = ReportParameters()
+        rpIncludeAlice.hmIncludedPlayerToParms = mapOf(alice to IncludedPlayerParameters())
+        val resultsAlice = runReportForTest(rpIncludeAlice)
+        resultsAlice.shouldContainExactlyInAnyOrder(gAllPlayers.localId, gAliceAndBob.localId, gAliceCliveDaisy.localId)
+
+        val rpIncludeAliceAndBob = ReportParameters()
+        rpIncludeAliceAndBob.hmIncludedPlayerToParms = mapOf(alice to IncludedPlayerParameters(), bob to IncludedPlayerParameters())
+        val resultsAliceAndBob = runReportForTest(rpIncludeAliceAndBob)
+        resultsAliceAndBob.shouldContainExactly(gAllPlayers.localId, gAliceAndBob.localId)
+    }
+
+    @Test
     fun `Should only include games with at least one human player if specified`()
     {
         val gAllPlayers = insertGame()

--- a/src/test/kotlin/dartzee/screen/TestPlayerSelectDialog.kt
+++ b/src/test/kotlin/dartzee/screen/TestPlayerSelectDialog.kt
@@ -1,6 +1,7 @@
 package dartzee.screen
 
 import dartzee.bean.getAllPlayers
+import dartzee.core.helper.doubleClick
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertPlayer
 import io.kotlintest.matchers.collections.shouldBeEmpty
@@ -64,6 +65,21 @@ class TestPlayerSelectDialog: AbstractTest()
 
         dlg.tablePlayers.selectRow(0)
         dlg.btnOk.doClick()
+
+        dialogFactory.errorsShown.shouldBeEmpty()
+        dlg.selectedPlayers.size shouldBe 1
+    }
+
+    @Test
+    fun `Should respond to double-click`()
+    {
+        insertPlayer(name = "Bob")
+
+        val dlg = PlayerSelectDialog(ListSelectionModel.SINGLE_SELECTION)
+        dlg.buildTable()
+
+        dlg.tablePlayers.selectRow(0)
+        dlg.tablePlayers.doubleClick()
 
         dialogFactory.errorsShown.shouldBeEmpty()
         dlg.selectedPlayers.size shouldBe 1

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCarousel.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCarousel.kt
@@ -272,7 +272,7 @@ class TestDartzeeRuleCarousel: AbstractTest()
         }
     }
 
-    private fun DartzeeRuleCarousel.getDisplayedTiles() = getAllChildComponentsForType(tilePanel, DartzeeRuleTile::class.java).filter { it.isVisible }
+    private fun DartzeeRuleCarousel.getDisplayedTiles() = tilePanel.getAllChildComponentsForType<DartzeeRuleTile>().filter { it.isVisible }
     private fun DartzeeRuleCarousel.getDisplayedRules() = getDisplayedTiles().map { it.dto }
     private fun makeCarousel(listener: IDartzeeCarouselListener = mockk(relaxed = true)) = DartzeeRuleCarousel(
         dtos

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
@@ -364,21 +364,21 @@ class TestDartzeeRuleCreationDialogInteraction : AbstractTest()
     {
         val dlg = DartzeeRuleCreationDialog()
 
-        var children = getAllChildComponentsForType(dlg, DartzeeDartRuleSelector::class.java)
+        var children = dlg.getAllChildComponentsForType<DartzeeDartRuleSelector>()
         children.shouldContainExactlyInAnyOrder(dlg.dartOneSelector, dlg.dartTwoSelector, dlg.dartThreeSelector)
         children.shouldNotContain(dlg.targetSelector)
 
         dlg.rdbtnAtLeastOne.doClick()
-        children = getAllChildComponentsForType(dlg, DartzeeDartRuleSelector::class.java)
+        children = dlg.getAllChildComponentsForType()
         children.shouldContainExactly(dlg.targetSelector)
 
         dlg.rdbtnAllDarts.doClick()
-        children = getAllChildComponentsForType(dlg, DartzeeDartRuleSelector::class.java)
+        children = dlg.getAllChildComponentsForType()
         children.shouldContainExactlyInAnyOrder(dlg.dartOneSelector, dlg.dartTwoSelector, dlg.dartThreeSelector)
         children.shouldNotContain(dlg.targetSelector)
 
         dlg.rdbtnNoDarts.doClick()
-        children = getAllChildComponentsForType(dlg, DartzeeDartRuleSelector::class.java)
+        children = dlg.getAllChildComponentsForType()
         children.shouldBeEmpty()
     }
 

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
@@ -229,7 +229,7 @@ class TestGamePanelDartzee: AbstractTest()
         verify { summaryPanel.update(listOf(), listOf(), 0, 1) }
     }
 
-    private fun DartzeeRuleCarousel.getDisplayedTiles() = getAllChildComponentsForType(tilePanel, DartzeeRuleTile::class.java).filter { it.isVisible }
+    private fun DartzeeRuleCarousel.getDisplayedTiles() = tilePanel.getAllChildComponentsForType<DartzeeRuleTile>().filter { it.isVisible }
 
     private fun setUpDartzeeGameOnDatabase(rounds: Int): GameEntity
     {

--- a/src/test/kotlin/dartzee/screen/game/rtc/TestGameStatisticsPanelRoundTheClock.kt
+++ b/src/test/kotlin/dartzee/screen/game/rtc/TestGameStatisticsPanelRoundTheClock.kt
@@ -175,7 +175,7 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
         statsPanel.shouldHaveBreakdownState(mapOf("2 - 3" to 1))
 
         //6
-        state = state.copy(darts = mutableListOf(missRound, hitRound))
+        state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(missRound, hitRound))
         statsPanel.showStats(listOf(state))
         statsPanel.shouldHaveBreakdownState(mapOf("4 - 6" to 1))
 

--- a/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
+++ b/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
@@ -1,6 +1,7 @@
 package dartzee.screen.reporting
 
 import dartzee.clickComponent
+import dartzee.core.bean.ComboBoxNumberComparison
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertPlayer
 import dartzee.reporting.COMPARATOR_SCORE_UNSET
@@ -86,7 +87,7 @@ class TestPlayerParametersPanel: AbstractTest()
         val panel = PlayerParametersPanel()
         panel.valid(player) shouldBe true
 
-        panel.clickComponent<JCheckBox>("Undecided")
+        panel.clickComponent<JCheckBox>("Position")
         panel.valid(player) shouldBe false
         dialogFactory.errorsShown.shouldContainExactly("You must select at least one finishing position for player Gordon")
         dialogFactory.errorsShown.clear()
@@ -99,5 +100,32 @@ class TestPlayerParametersPanel: AbstractTest()
         panel.clickComponent<JCheckBox>("1st")
         panel.valid(player) shouldBe true
         dialogFactory.errorsShown.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Should generate the correct parameters for final score`()
+    {
+        val panel = PlayerParametersPanel()
+        panel.clickComponent<JCheckBox>("Game Score")
+        panel.spinner.value = 20
+        panel.comboBox.selectedItem = ComboBoxNumberComparison.FILTER_MODE_GREATER_THAN
+
+        val params = panel.generateParameters()
+        params.finalScore shouldBe 20
+        params.finalScoreComparator shouldBe ComboBoxNumberComparison.FILTER_MODE_GREATER_THAN
+    }
+
+    @Test
+    fun `Should generate the correct parameters for position`()
+    {
+        val panel = PlayerParametersPanel()
+        panel.clickComponent<JCheckBox>("Position")
+        panel.clickComponent<JCheckBox>("1st")
+        panel.clickComponent<JCheckBox>("5th")
+        panel.clickComponent<JCheckBox>("Undecided")
+
+
+        val params = panel.generateParameters()
+        params.finishingPositions.shouldContainExactly(1, 5, -1)
     }
 }

--- a/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
+++ b/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
@@ -1,5 +1,6 @@
 package dartzee.screen.reporting
 
+import dartzee.clickComponent
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertPlayer
 import dartzee.reporting.COMPARATOR_SCORE_UNSET
@@ -8,6 +9,7 @@ import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.shouldBe
 import org.junit.Test
+import javax.swing.JCheckBox
 
 class TestPlayerParametersPanel: AbstractTest()
 {
@@ -84,17 +86,17 @@ class TestPlayerParametersPanel: AbstractTest()
         val panel = PlayerParametersPanel()
         panel.valid(player) shouldBe true
 
-        panel.chckbxPosition.doClick()
+        panel.clickComponent<JCheckBox>("Undecided")
         panel.valid(player) shouldBe false
         dialogFactory.errorsShown.shouldContainExactly("You must select at least one finishing position for player Gordon")
         dialogFactory.errorsShown.clear()
 
-        panel.cbUndecided.doClick()
+        panel.clickComponent<JCheckBox>("Undecided")
         panel.valid(player) shouldBe true
         dialogFactory.errorsShown.shouldBeEmpty()
 
         panel.cbUndecided.doClick()
-        panel.positionCheckboxes.first().doClick()
+        panel.clickComponent<JCheckBox>("1st")
         panel.valid(player) shouldBe true
         dialogFactory.errorsShown.shouldBeEmpty()
     }

--- a/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
+++ b/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
@@ -1,8 +1,11 @@
 package dartzee.screen.reporting
 
 import dartzee.helper.AbstractTest
+import dartzee.helper.insertPlayer
 import dartzee.reporting.COMPARATOR_SCORE_UNSET
 import dartzee.reporting.IncludedPlayerParameters
+import io.kotlintest.matchers.collections.shouldBeEmpty
+import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.shouldBe
 import org.junit.Test
 
@@ -71,5 +74,28 @@ class TestPlayerParametersPanel: AbstractTest()
 
         panel.comboBox.selectedIndex = 0
         panel.spinner.isEnabled shouldBe true
+    }
+
+    @Test
+    fun `Should not be valid if position is selected but nothing ticked`()
+    {
+        val player = insertPlayer(name = "Gordon")
+
+        val panel = PlayerParametersPanel()
+        panel.valid(player) shouldBe true
+
+        panel.chckbxPosition.doClick()
+        panel.valid(player) shouldBe false
+        dialogFactory.errorsShown.shouldContainExactly("You must select at least one finishing position for player Gordon")
+        dialogFactory.errorsShown.clear()
+
+        panel.cbUndecided.doClick()
+        panel.valid(player) shouldBe true
+        dialogFactory.errorsShown.shouldBeEmpty()
+
+        panel.cbUndecided.doClick()
+        panel.positionCheckboxes.first().doClick()
+        panel.valid(player) shouldBe true
+        dialogFactory.errorsShown.shouldBeEmpty()
     }
 }

--- a/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
+++ b/src/test/kotlin/dartzee/screen/reporting/TestPlayerParametersPanel.kt
@@ -1,0 +1,75 @@
+package dartzee.screen.reporting
+
+import dartzee.helper.AbstractTest
+import dartzee.reporting.COMPARATOR_SCORE_UNSET
+import dartzee.reporting.IncludedPlayerParameters
+import io.kotlintest.shouldBe
+import org.junit.Test
+
+class TestPlayerParametersPanel: AbstractTest()
+{
+    @Test
+    fun `Should support disabling all components`()
+    {
+        val panel = PlayerParametersPanel()
+        panel.disableAll()
+
+        panel.components.forEach { it.isEnabled shouldBe false }
+    }
+
+    @Test
+    fun `Should having nothing selected by default, and generate empty parameters`()
+    {
+        val panel = PlayerParametersPanel()
+        panel.chckbxPosition.isSelected shouldBe false
+        panel.chckbxFinalScore.isSelected shouldBe false
+
+        panel.generateParameters() shouldBe IncludedPlayerParameters()
+    }
+
+    @Test
+    fun `Should enable and disable the position checkboxes`()
+    {
+        val panel = PlayerParametersPanel()
+        panel.positionCheckboxes.forEach { it.isEnabled shouldBe false }
+        panel.cbUndecided.isEnabled shouldBe false
+
+        panel.chckbxPosition.doClick()
+        panel.positionCheckboxes.forEach { it.isEnabled shouldBe true }
+        panel.cbUndecided.isEnabled shouldBe true
+
+        panel.chckbxPosition.doClick()
+        panel.positionCheckboxes.forEach { it.isEnabled shouldBe false }
+        panel.cbUndecided.isEnabled shouldBe false
+    }
+
+    @Test
+    fun `Should enable and disable the score options`()
+    {
+        val panel = PlayerParametersPanel()
+        panel.comboBox.isEnabled shouldBe false
+        panel.spinner.isEnabled shouldBe false
+
+        panel.chckbxFinalScore.doClick()
+        panel.comboBox.isEnabled shouldBe true
+        panel.spinner.isEnabled shouldBe true
+
+        panel.chckbxFinalScore.doClick()
+        panel.comboBox.isEnabled shouldBe false
+        panel.spinner.isEnabled shouldBe false
+    }
+
+    @Test
+    fun `Should enable and disable the spinner based on combo selection`()
+    {
+        val panel = PlayerParametersPanel()
+        panel.chckbxFinalScore.doClick()
+        panel.spinner.isEnabled shouldBe true
+
+        panel.comboBox.selectedItem = COMPARATOR_SCORE_UNSET
+        panel.spinner.isEnabled shouldBe false
+
+        panel.comboBox.selectedIndex = 0
+        panel.spinner.isEnabled shouldBe true
+    }
+}

--- a/src/test/kotlin/dartzee/screen/reporting/TestReportingPlayersTab.kt
+++ b/src/test/kotlin/dartzee/screen/reporting/TestReportingPlayersTab.kt
@@ -1,0 +1,209 @@
+package dartzee.screen.reporting
+
+import dartzee.helper.AbstractTest
+import dartzee.helper.insertPlayer
+import dartzee.reporting.IncludedPlayerParameters
+import dartzee.reporting.ReportParameters
+import io.kotlintest.matchers.collections.shouldBeEmpty
+import io.kotlintest.matchers.collections.shouldContain
+import io.kotlintest.matchers.collections.shouldContainExactly
+import io.kotlintest.matchers.collections.shouldNotContain
+import io.kotlintest.matchers.maps.shouldContainExactly
+import io.kotlintest.shouldBe
+import org.junit.Test
+
+class TestReportingPlayersTab: AbstractTest()
+{
+    @Test
+    fun `Should initialise with an empty player table`()
+    {
+        val tab = ReportingPlayersTab()
+        tab.scrollTable.lblRowCount.text shouldBe "0 players"
+    }
+
+    @Test
+    fun `Should show an error if trying to remove without a selected row`()
+    {
+        val tab = ReportingPlayersTab()
+        tab.addPlayers(listOf(insertPlayer()))
+        tab.scrollTable.selectRow(-1)
+
+        tab.btnRemovePlayer.doClick()
+
+        tab.scrollTable.rowCount shouldBe 1
+        dialogFactory.errorsShown.shouldContainExactly("You must select player(s) to remove.")
+    }
+
+    @Test
+    fun `Should remove a player and reset their included parameters`()
+    {
+        val p = insertPlayer()
+        val tab = ReportingPlayersTab()
+        tab.addPlayers(listOf(p))
+
+        tab.includedPlayerPanel.enabled() shouldBe true
+        tab.includedPlayerPanel.chckbxFinalScore.doClick()
+
+        tab.btnRemovePlayer.doClick()
+        tab.scrollTable.rowCount shouldBe 0
+
+        tab.addPlayers(listOf(p))
+
+        tab.includedPlayerPanel.chckbxFinalScore.isSelected shouldBe false
+    }
+
+    @Test
+    fun `Should enable, disable and hide the player parameter panel as appropriate`()
+    {
+        val p1 = insertPlayer()
+        val p2 = insertPlayer()
+        val tab = ReportingPlayersTab()
+        tab.includedPlayerPanel.enabled() shouldBe false
+
+        tab.addPlayers(listOf(p1, p2))
+        tab.includedPlayerPanel.enabled() shouldBe true
+        tab.includedPlayerPanel.chckbxFinalScore.doClick()
+
+        tab.scrollTable.selectRow(1)
+        tab.includedPlayerPanel.enabled() shouldBe true
+        tab.includedPlayerPanel.chckbxFinalScore.isSelected shouldBe false
+
+        tab.scrollTable.selectRow(0)
+        tab.includedPlayerPanel.enabled() shouldBe true
+        tab.includedPlayerPanel.chckbxFinalScore.isSelected shouldBe true
+
+        tab.scrollTable.selectRow(-1)
+        tab.includedPlayerPanel.enabled() shouldBe false
+        tab.includedPlayerPanel.chckbxFinalScore.isSelected shouldBe false
+
+        tab.components.toList().shouldContain(tab.includedPlayerPanel)
+
+        tab.rdbtnExclude.doClick()
+        tab.components.toList().shouldNotContain(tab.includedPlayerPanel)
+
+        tab.scrollTable.selectRow(0)
+        tab.components.toList().shouldNotContain(tab.includedPlayerPanel)
+
+        tab.rdbtnInclude.doClick()
+        tab.components.toList().shouldContain(tab.includedPlayerPanel)
+        tab.includedPlayerPanel.enabled() shouldBe true
+        tab.includedPlayerPanel.chckbxFinalScore.isSelected shouldBe true
+    }
+
+    @Test
+    fun `Should populate report parameters correctly with no players selected`()
+    {
+        val tab = ReportingPlayersTab()
+
+        val rp = ReportParameters()
+        tab.populateReportParameters(rp)
+        rp.excludedPlayers.shouldBeEmpty()
+        rp.hmIncludedPlayerToParms.size shouldBe 0
+
+        tab.rdbtnExclude.doClick()
+        tab.populateReportParameters(rp)
+        rp.excludedPlayers.shouldBeEmpty()
+        rp.hmIncludedPlayerToParms.size shouldBe 0
+    }
+
+    @Test
+    fun `Should populate excludeOnlyAi correctly`()
+    {
+        val tab = ReportingPlayersTab()
+        val rp = ReportParameters()
+
+        tab.populateReportParameters(rp)
+        rp.excludeOnlyAi shouldBe false
+
+        tab.checkBoxExcludeOnlyAi.doClick()
+        tab.populateReportParameters(rp)
+        rp.excludeOnlyAi shouldBe true
+
+        tab.checkBoxExcludeOnlyAi.doClick()
+        tab.populateReportParameters(rp)
+        rp.excludeOnlyAi shouldBe false
+    }
+
+    @Test
+    fun `Should populate included players correctly`()
+    {
+        val playerOne = insertPlayer()
+        val playerTwo = insertPlayer()
+
+        val tab = ReportingPlayersTab()
+        tab.addPlayers(listOf(playerOne, playerTwo))
+        tab.includedPlayerPanel.chckbxFinalScore.doClick()
+
+        val rp = ReportParameters()
+        tab.populateReportParameters(rp)
+
+        rp.excludedPlayers.shouldBeEmpty()
+        rp.hmIncludedPlayerToParms.shouldContainExactly(mapOf(playerOne to IncludedPlayerParameters(listOf(), "=", 3), playerTwo to IncludedPlayerParameters()))
+    }
+
+    @Test
+    fun `Should populate excluded players correctly`()
+    {
+        val playerOne = insertPlayer()
+        val playerTwo = insertPlayer()
+
+        val tab = ReportingPlayersTab()
+        tab.addPlayers(listOf(playerOne, playerTwo))
+        tab.includedPlayerPanel.chckbxFinalScore.doClick()
+        tab.rdbtnExclude.doClick()
+
+        val rp = ReportParameters()
+        tab.populateReportParameters(rp)
+
+        rp.excludedPlayers.shouldContainExactly(playerOne, playerTwo)
+        rp.hmIncludedPlayerToParms.size shouldBe 0
+    }
+
+    @Test
+    fun `Should validate all the included player parameters`()
+    {
+        val playerOne = insertPlayer(name = "Alice")
+        val playerTwo = insertPlayer(name = "Bob")
+
+        val tab = ReportingPlayersTab()
+        tab.addPlayers(listOf(playerOne, playerTwo))
+
+        //Make both invalid
+        tab.includedPlayerPanel.chckbxPosition.doClick()
+        tab.scrollTable.selectRow(1)
+        tab.includedPlayerPanel.chckbxPosition.doClick()
+
+        tab.valid() shouldBe false
+        dialogFactory.errorsShown.shouldContainExactly("You must select at least one finishing position for player Alice")
+
+        dialogFactory.errorsShown.clear()
+        tab.scrollTable.selectRow(0)
+        tab.includedPlayerPanel.chckbxPosition.doClick()
+        tab.valid() shouldBe false
+        dialogFactory.errorsShown.shouldContainExactly("You must select at least one finishing position for player Bob")
+
+        dialogFactory.errorsShown.clear()
+        tab.scrollTable.selectRow(1)
+        tab.includedPlayerPanel.chckbxPosition.doClick()
+        tab.valid() shouldBe true
+        dialogFactory.errorsShown.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Should not do any validation in exclude mode`()
+    {
+        val playerOne = insertPlayer()
+
+        val tab = ReportingPlayersTab()
+        tab.addPlayers(listOf(playerOne))
+
+        //Make invalid, but then swap to exclude mode
+        tab.includedPlayerPanel.chckbxPosition.doClick()
+        tab.rdbtnExclude.doClick()
+
+        tab.valid() shouldBe true
+        dialogFactory.errorsShown.shouldBeEmpty()
+    }
+
+    private fun PlayerParametersPanel.enabled() = chckbxFinalScore.isEnabled
+}

--- a/src/test/kotlin/dartzee/screen/stats/player/AbstractPlayerStatisticsTest.kt
+++ b/src/test/kotlin/dartzee/screen/stats/player/AbstractPlayerStatisticsTest.kt
@@ -39,19 +39,19 @@ abstract class AbstractPlayerStatisticsTest<E: AbstractStatisticsTab>: AbstractT
         tab.setFilteredGames(listOf(constructGameWrapper()), listOf())
         tab.populateStats()
         components.forEach{
-            containsComponent(tab, it) shouldBe false
+            tab.containsComponent(it) shouldBe false
         }
 
         tab.setFilteredGames(listOf(constructGameWrapper()), listOf(constructGameWrapper()))
         tab.populateStats()
         components.forEach{
-            containsComponent(tab, it) shouldBe true
+            tab.containsComponent(it) shouldBe true
         }
 
         tab.setFilteredGames(listOf(constructGameWrapper()), listOf())
         tab.populateStats()
         components.forEach{
-            containsComponent(tab, it) shouldBe false
+            tab.containsComponent(it) shouldBe false
         }
     }
 


### PR DESCRIPTION
Trello: https://trello.com/c/1ahPyf9x

- Combine "Players" and "Excluded players" reporting tabs, refactor out as separate class.
- Add tests to cover new tab, and the `PlayerParametersPanel`
- Add checkbox to new tab for "Exclude games with only AI players". Plug this into the report SQL and add tests.