### PR TITLE
Persist logs

### DIFF
--- a/src/main/kotlin/dartzee/db/AbstractEntity.kt
+++ b/src/main/kotlin/dartzee/db/AbstractEntity.kt
@@ -187,6 +187,8 @@ abstract class AbstractEntity<E : AbstractEntity<E>>
         return DatabaseUtil.executeUpdate(sql)
     }
 
+    fun deleteAll() = DatabaseUtil.executeUpdate("DELETE FROM ${getTableName()}")
+
     fun deleteWhere(whereSql: String): Boolean
     {
         val sql = "DELETE FROM ${getTableName()} WHERE $whereSql"

--- a/src/main/kotlin/dartzee/db/PendingLogsEntity.kt
+++ b/src/main/kotlin/dartzee/db/PendingLogsEntity.kt
@@ -9,7 +9,6 @@ class PendingLogsEntity: AbstractEntity<PendingLogsEntity>()
 
     override fun getCreateTableSqlSpecific() = "LogJson varchar(30000) NOT NULL"
 
-
     companion object
     {
         fun factory(logJson: String): PendingLogsEntity

--- a/src/main/kotlin/dartzee/db/PendingLogsEntity.kt
+++ b/src/main/kotlin/dartzee/db/PendingLogsEntity.kt
@@ -1,0 +1,23 @@
+package dartzee.db
+
+class PendingLogsEntity: AbstractEntity<PendingLogsEntity>()
+{
+    //DB Fields
+    var logJson = ""
+
+    override fun getTableName() = "PendingLogs"
+
+    override fun getCreateTableSqlSpecific() = "LogJson varchar(30000) NOT NULL"
+
+
+    companion object
+    {
+        fun factory(logJson: String): PendingLogsEntity
+        {
+            val entity = PendingLogsEntity()
+            entity.assignRowId()
+            entity.logJson = logJson
+            return entity
+        }
+    }
+}

--- a/src/main/kotlin/dartzee/logging/LogDestinationElasticsearch.kt
+++ b/src/main/kotlin/dartzee/logging/LogDestinationElasticsearch.kt
@@ -1,5 +1,6 @@
 package dartzee.logging
 
+import dartzee.`object`.DartsClient
 import dartzee.db.BulkInserter
 import dartzee.db.PendingLogsEntity
 import dartzee.utils.InjectedThings.logger
@@ -13,7 +14,10 @@ class LogDestinationElasticsearch(private val poster: ElasticsearchPoster?, priv
 
     override fun log(record: LogRecord)
     {
-        pendingLogs.add(record.toJsonString())
+        if (!DartsClient.devMode)
+        {
+            pendingLogs.add(record.toJsonString())
+        }
     }
 
     override fun contextUpdated(context: Map<String, Any?>){}

--- a/src/main/kotlin/dartzee/logging/LogDestinationElasticsearch.kt
+++ b/src/main/kotlin/dartzee/logging/LogDestinationElasticsearch.kt
@@ -55,5 +55,4 @@ class LogDestinationElasticsearch(private val poster: ElasticsearchPoster?, priv
         val entities = remainingLogs.map { PendingLogsEntity.factory(it) }
         BulkInserter.insert(entities)
     }
-
 }

--- a/src/main/kotlin/dartzee/logging/LogDestinationElasticsearch.kt
+++ b/src/main/kotlin/dartzee/logging/LogDestinationElasticsearch.kt
@@ -1,16 +1,19 @@
 package dartzee.logging
 
+import dartzee.db.BulkInserter
+import dartzee.db.PendingLogsEntity
+import dartzee.utils.InjectedThings.logger
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 class LogDestinationElasticsearch(private val poster: ElasticsearchPoster?, private val scheduler: ScheduledExecutorService): ILogDestination
 {
-    private val pendingLogs = ConcurrentHashMap.newKeySet<LogRecord>()
+    private val pendingLogs = ConcurrentHashMap.newKeySet<String>()
 
     override fun log(record: LogRecord)
     {
-        pendingLogs.add(record)
+        pendingLogs.add(record.toJsonString())
     }
 
     override fun contextUpdated(context: Map<String, Any?>){}
@@ -26,12 +29,31 @@ class LogDestinationElasticsearch(private val poster: ElasticsearchPoster?, priv
         val logsForThisRun = pendingLogs.toList()
         logsForThisRun.forEach(::postLogToElasticsearch)
     }
-    private fun postLogToElasticsearch(log: LogRecord)
+    private fun postLogToElasticsearch(logJson: String)
     {
-        val logJson = log.toJsonString()
         if (poster?.postLog(logJson) == true)
         {
-            pendingLogs.remove(log)
+            pendingLogs.remove(logJson)
         }
     }
+
+
+    fun readOldLogs()
+    {
+        val persistedLogs = PendingLogsEntity().retrieveEntities().map { it.logJson }
+        pendingLogs.addAll(persistedLogs)
+
+        PendingLogsEntity().deleteAll()
+    }
+
+    fun shutDown()
+    {
+        scheduler.shutdown()
+        logger.waitUntilLoggingFinished()
+
+        val remainingLogs = pendingLogs.toList()
+        val entities = remainingLogs.map { PendingLogsEntity.factory(it) }
+        BulkInserter.insert(entities)
+    }
+
 }

--- a/src/main/kotlin/dartzee/main/ApplicationExit.kt
+++ b/src/main/kotlin/dartzee/main/ApplicationExit.kt
@@ -1,0 +1,25 @@
+package dartzee.main
+
+import dartzee.core.util.DialogUtil
+import dartzee.screen.ScreenCache
+import dartzee.utils.InjectedThings
+import javax.swing.JOptionPane
+import kotlin.system.exitProcess
+
+fun exitApplication()
+{
+    val openGames = ScreenCache.getDartsGameScreens()
+    val size = openGames.size
+    if (size > 0)
+    {
+        val ans = DialogUtil.showQuestion("Are you sure you want to exit? There are $size game window(s) still open.", false)
+        if (ans == JOptionPane.NO_OPTION)
+        {
+            return
+        }
+    }
+
+    InjectedThings.esDestination.shutDown()
+
+    exitProcess(0)
+}

--- a/src/main/kotlin/dartzee/main/DartsMain.kt
+++ b/src/main/kotlin/dartzee/main/DartsMain.kt
@@ -6,6 +6,7 @@ import dartzee.core.util.MessageDialogFactory
 import dartzee.logging.LoggerUncaughtExceptionHandler
 import dartzee.screen.ScreenCache
 import dartzee.utils.InjectedThings
+import javax.swing.JOptionPane
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>)
@@ -33,4 +34,22 @@ fun main(args: Array<String>)
     val mainScreen = ScreenCache.mainScreen
     mainScreen.isVisible = true
     mainScreen.init()
+}
+
+fun exitApplication()
+{
+    val openGames = ScreenCache.getDartsGameScreens()
+    val size = openGames.size
+    if (size > 0)
+    {
+        val ans = DialogUtil.showQuestion("Are you sure you want to exit? There are $size game window(s) still open.", false)
+        if (ans == JOptionPane.NO_OPTION)
+        {
+            return
+        }
+    }
+
+    InjectedThings.esDestination.shutDown()
+
+    exitProcess(0)
 }

--- a/src/main/kotlin/dartzee/main/DartsMain.kt
+++ b/src/main/kotlin/dartzee/main/DartsMain.kt
@@ -6,7 +6,6 @@ import dartzee.core.util.MessageDialogFactory
 import dartzee.logging.LoggerUncaughtExceptionHandler
 import dartzee.screen.ScreenCache
 import dartzee.utils.InjectedThings
-import javax.swing.JOptionPane
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>)
@@ -34,22 +33,4 @@ fun main(args: Array<String>)
     val mainScreen = ScreenCache.mainScreen
     mainScreen.isVisible = true
     mainScreen.init()
-}
-
-fun exitApplication()
-{
-    val openGames = ScreenCache.getDartsGameScreens()
-    val size = openGames.size
-    if (size > 0)
-    {
-        val ans = DialogUtil.showQuestion("Are you sure you want to exit? There are $size game window(s) still open.", false)
-        if (ans == JOptionPane.NO_OPTION)
-        {
-            return
-        }
-    }
-
-    InjectedThings.esDestination.shutDown()
-
-    exitProcess(0)
 }

--- a/src/main/kotlin/dartzee/screen/DartsApp.kt
+++ b/src/main/kotlin/dartzee/screen/DartsApp.kt
@@ -11,8 +11,10 @@ import dartzee.db.sanity.DatabaseSanityCheck
 import dartzee.logging.CODE_SCREEN_LOAD_ERROR
 import dartzee.logging.KEY_CURRENT_SCREEN
 import dartzee.logging.LoggingCode
+import dartzee.main.exitApplication
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.DevUtilities
+import dartzee.utils.InjectedThings
 import dartzee.utils.InjectedThings.gameLauncher
 import dartzee.utils.InjectedThings.logger
 import dartzee.utils.ResourceCache
@@ -55,6 +57,8 @@ class DartsApp(commandBar: CheatBar) : AbstractDevScreen(commandBar), WindowList
         ResourceCache.initialiseResources()
 
         DartsDatabaseUtil.initialiseDatabase()
+
+        InjectedThings.esDestination.readOldLogs()
 
         addConsoleShortcut()
         switchScreen(ScreenCache.getScreen(MenuScreen::class.java))
@@ -223,6 +227,6 @@ class DartsApp(commandBar: CheatBar) : AbstractDevScreen(commandBar), WindowList
 
     override fun windowClosing(arg0: WindowEvent)
     {
-        ScreenCache.exitApplication()
+        exitApplication()
     }
 }

--- a/src/main/kotlin/dartzee/screen/MenuScreen.kt
+++ b/src/main/kotlin/dartzee/screen/MenuScreen.kt
@@ -1,6 +1,7 @@
 package dartzee.screen
 
 import dartzee.core.util.addActionListenerToAllChildren
+import dartzee.main.exitApplication
 import dartzee.screen.reporting.ReportingSetupScreen
 import dartzee.screen.stats.overall.LeaderboardsScreen
 import java.awt.BorderLayout
@@ -97,7 +98,7 @@ class MenuScreen : EmbeddedScreen()
                 dialog.isVisible = true
             }
 
-            btnExit -> ScreenCache.exitApplication()
+            btnExit -> exitApplication()
             btnNewGame -> ScreenCache.switchScreen(GameSetupScreen::class.java)
             btnManagePlayers -> ScreenCache.switchScreen(PlayerManagementScreen::class.java)
             btnGameReport -> ScreenCache.switchScreen(ReportingSetupScreen::class.java)

--- a/src/main/kotlin/dartzee/screen/ScreenCache.kt
+++ b/src/main/kotlin/dartzee/screen/ScreenCache.kt
@@ -97,6 +97,7 @@ object ScreenCache
     fun emptyCache()
     {
         hmClassToScreen.clear()
+        hmGameIdToGameScreen.clear()
 
         humanCreationDialog = null
         aiConfigurationDialog = null

--- a/src/main/kotlin/dartzee/screen/ScreenCache.kt
+++ b/src/main/kotlin/dartzee/screen/ScreenCache.kt
@@ -1,14 +1,11 @@
 package dartzee.screen
 
 import dartzee.core.bean.CheatBar
-import dartzee.core.util.DialogUtil
 import dartzee.logging.LoggingConsole
 import dartzee.screen.ai.AIConfigurationDialog
 import dartzee.screen.game.AbstractDartsGameScreen
 import dartzee.screen.preference.PreferencesDialog
 import dartzee.screen.reporting.ConfigureReportColumnsDialog
-import javax.swing.JOptionPane
-import kotlin.system.exitProcess
 
 object ScreenCache
 {
@@ -95,22 +92,6 @@ object ScreenCache
         }
 
         return configureReportColumnsDialog!!
-    }
-
-    fun exitApplication()
-    {
-        val openGames = getDartsGameScreens()
-        val size = openGames.size
-        if (size > 0)
-        {
-            val ans = DialogUtil.showQuestion("Are you sure you want to exit? There are $size game window(s) still open.", false)
-            if (ans == JOptionPane.NO_OPTION)
-            {
-                return
-            }
-        }
-
-        exitProcess(0)
     }
 
     fun emptyCache()

--- a/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
+++ b/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
@@ -1,5 +1,5 @@
 package dartzee.utils
 
-const val DARTS_VERSION_NUMBER = "v4.1.1"
+const val DARTS_VERSION_NUMBER = "v4.2.0"
 const val DARTZEE_REPOSITORY_URL = "https://api.github.com/repos/alexburlton/Dartzee"
 const val DARTZEE_MANUAL_DOWNLOAD_URL = "https://github.com/alexburlton/Dartzee/releases"

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -40,7 +40,8 @@ object DartsDatabaseUtil
                 DartzeeRuleEntity(),
                 DartzeeTemplateEntity(),
                 DartzeeRoundResultEntity(),
-                X01FinishEntity())
+                X01FinishEntity(),
+                PendingLogsEntity())
     }
 
     fun getAllEntitiesIncludingVersion(): MutableList<AbstractEntity<*>>
@@ -120,6 +121,8 @@ object DartsDatabaseUtil
         else if (versionNumber == 10)
         {
             runSqlScriptsForVersion(11)
+
+            PendingLogsEntity().createTable()
 
             //Added "ScoringSegments"
             DartzeeRuleConversion.convertDartzeeRules()

--- a/src/main/resources/ChangeLog
+++ b/src/main/resources/ChangeLog
@@ -11,6 +11,7 @@
 = Allow reporting on a player finishing 5th or 6th.
 = Fix bug with RTC stats being incorrectly aggregated for matches
 = Improved support for non-windows operating systems
+= 57.8% test coverage (7357 / 12,728 lines covered by 1356 tests)
 
 --------- v4.1.0 ---------
 

--- a/src/main/resources/ChangeLog
+++ b/src/main/resources/ChangeLog
@@ -3,6 +3,7 @@
 + Improved dartboard highlighting in Dartzee so it's clearer where to aim
 + Ability to exclude "all AI" games from reporting. Combined and clarified existing player options.
 + Bruce appearance on failed bonus shots in Round the Clock
+= Logging rewrite
 = Fix bug with Optimal Scorecard rendering
 = Fix bug with the number of games in "First To" matches
 = Fix bug with layout of player selectors

--- a/src/main/resources/ChangeLog
+++ b/src/main/resources/ChangeLog
@@ -1,12 +1,14 @@
---------- v4.1.1 ---------
+--------- v4.2.0 ---------
 
-+ Ability to exclude "all AI" games from reporting. Clarified existing player options.
++ Improved dartboard highlighting in Dartzee so it's clearer where to aim
++ Ability to exclude "all AI" games from reporting. Combined and clarified existing player options.
 + Bruce appearance on failed bonus shots in Round the Clock
 = Fix bug with Optimal Scorecard rendering
 = Fix bug with the number of games in "First To" matches
 = Fix bug with layout of player selectors
 = Fix bug trying to launch a custom match of Dartzee
-= Fix points based matches to support 6 players
+= Fix points based matches to support 6 players.
+= Allow reporting on a player finishing 5th or 6th.
 = Fix bug with RTC stats being incorrectly aggregated for matches
 = Improved support for non-windows operating systems
 

--- a/src/test/kotlin/dartzee/db/TestPendingLogsEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestPendingLogsEntity.kt
@@ -1,0 +1,20 @@
+package dartzee.db
+
+import io.kotlintest.matchers.string.shouldNotBeEmpty
+import io.kotlintest.shouldBe
+import org.junit.Test
+
+class TestPendingLogsEntity: AbstractEntityTest<PendingLogsEntity>()
+{
+    override fun factoryDao() = PendingLogsEntity()
+
+    @Test
+    fun `Should factory with an assigned rowId and the specified JSON`()
+    {
+        val logJson = "foo"
+
+        val e = PendingLogsEntity.factory(logJson)
+        e.logJson shouldBe logJson
+        e.rowId.shouldNotBeEmpty()
+    }
+}

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -6,6 +6,7 @@ import dartzee.core.helper.TestMessageDialogFactory
 import dartzee.core.util.DialogUtil
 import dartzee.db.LocalIdGenerator
 import dartzee.logging.*
+import dartzee.screen.ScreenCache
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.InjectedThings
 import io.kotlintest.shouldBe
@@ -70,6 +71,7 @@ abstract class AbstractTest
 
     open fun beforeEachTest()
     {
+        ScreenCache.emptyCache()
         dialogFactory.reset()
         clearLogs()
         clearAllMocks()

--- a/src/test/kotlin/dartzee/helper/ExitAssertions.kt
+++ b/src/test/kotlin/dartzee/helper/ExitAssertions.kt
@@ -1,0 +1,65 @@
+package dartzee.helper
+
+import io.kotlintest.fail
+import io.kotlintest.shouldBe
+import java.security.Permission
+
+private class ExitException(val status: Int): SecurityException("Nope")
+private class NoExitSecurityManager(val originalSecurityManager: SecurityManager?): SecurityManager()
+{
+    override fun checkPermission(perm: Permission?)
+    {
+        originalSecurityManager?.checkPermission(perm)
+    }
+
+    override fun checkPermission(perm: Permission?, context: Any?)
+    {
+        originalSecurityManager?.checkPermission(perm, context)
+    }
+
+    override fun checkExit(status: Int)
+    {
+        super.checkExit(status)
+        throw ExitException(status)
+    }
+}
+
+
+fun assertExits(expectedStatus: Int, fn: () -> Unit)
+{
+    val originalSecurityManager = System.getSecurityManager()
+    System.setSecurityManager(NoExitSecurityManager(originalSecurityManager))
+
+    try
+    {
+        fn()
+        fail("Expected exitProcess($expectedStatus), but it wasn't called")
+    }
+    catch (e: ExitException)
+    {
+        e.status shouldBe expectedStatus
+    }
+    finally
+    {
+        System.setSecurityManager(originalSecurityManager)
+    }
+}
+
+fun assertDoesNotExit(fn: () -> Unit)
+{
+    val originalSecurityManager = System.getSecurityManager()
+    System.setSecurityManager(NoExitSecurityManager(originalSecurityManager))
+
+    try
+    {
+        fn()
+    }
+    catch (e: ExitException)
+    {
+        fail("Called exitProcess(${e.status})")
+    }
+    finally
+    {
+        System.setSecurityManager(originalSecurityManager)
+    }
+}

--- a/src/test/kotlin/dartzee/logging/TestLogDestinationElasticsearch.kt
+++ b/src/test/kotlin/dartzee/logging/TestLogDestinationElasticsearch.kt
@@ -1,5 +1,6 @@
 package dartzee.logging
 
+import dartzee.`object`.DartsClient
 import dartzee.core.helper.verifyNotCalled
 import dartzee.db.PendingLogsEntity
 import dartzee.helper.AbstractTest
@@ -18,6 +19,28 @@ import java.util.concurrent.TimeUnit
 
 class TestLogDestinationElasticsearch: AbstractTest()
 {
+    @Test
+    override fun beforeEachTest()
+    {
+        super.beforeEachTest()
+
+        DartsClient.devMode = false
+    }
+
+    @Test
+    fun `Should not post logs in dev mode`()
+    {
+        DartsClient.devMode = true
+
+        val poster = mockPoster()
+        val dest = makeLogDestination(poster)
+
+        dest.log(makeLogRecord())
+        dest.postPendingLogs()
+
+        verifyNotCalled { poster.postLog(any()) }
+    }
+
     @Test
     fun `Should queue up logs to be posted in the next run`()
     {

--- a/src/test/kotlin/dartzee/main/TestApplicationExit.kt
+++ b/src/test/kotlin/dartzee/main/TestApplicationExit.kt
@@ -1,0 +1,66 @@
+package dartzee.main
+
+import dartzee.helper.AbstractTest
+import dartzee.helper.assertDoesNotExit
+import dartzee.helper.assertExits
+import dartzee.logging.LogDestinationElasticsearch
+import dartzee.screen.ScreenCache
+import dartzee.utils.InjectedThings
+import io.kotlintest.matchers.collections.shouldBeEmpty
+import io.kotlintest.matchers.collections.shouldContainExactly
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import javax.swing.JOptionPane
+
+class TestApplicationExit: AbstractTest()
+{
+    @Test
+    fun `Should exit without prompt if no games are open`()
+    {
+        assertExits(0) {
+            exitApplication()
+        }
+
+        dialogFactory.questionsShown.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Should not exit if there are open windows and user does not confirm`()
+    {
+        dialogFactory.questionOption = JOptionPane.NO_OPTION
+        ScreenCache.addDartsGameScreen("foo", mockk(relaxed = true))
+
+        assertDoesNotExit {
+            exitApplication()
+        }
+
+        dialogFactory.questionsShown.shouldContainExactly("Are you sure you want to exit? There are 1 game window(s) still open.")
+    }
+
+    @Test
+    fun `Should exit if there are open windows and user does confirms`()
+    {
+        dialogFactory.questionOption = JOptionPane.YES_OPTION
+        ScreenCache.addDartsGameScreen("foo", mockk(relaxed = true))
+
+        assertExits(0) {
+            exitApplication()
+        }
+
+        dialogFactory.questionsShown.shouldContainExactly("Are you sure you want to exit? There are 1 game window(s) still open.")
+    }
+
+    @Test
+    fun `Should shut down the elasticsearch service`()
+    {
+        val mockEsDestination = mockk<LogDestinationElasticsearch>(relaxed = true)
+        InjectedThings.esDestination = mockEsDestination
+
+        assertExits(0) {
+            exitApplication()
+        }
+
+        verify { mockEsDestination.shutDown() }
+    }
+}

--- a/src/test/kotlin/dartzee/main/TestMainUtil.kt
+++ b/src/test/kotlin/dartzee/main/TestMainUtil.kt
@@ -27,6 +27,7 @@ class TestMainUtil: AbstractTest()
 
     override fun afterEachTest()
     {
+        super.afterEachTest()
         instance.put(INSTANCE_STRING_DEVICE_ID, originalDeviceId)
         instance.put(INSTANCE_STRING_USER_NAME, originalUsername)
     }


### PR DESCRIPTION
Trello: https://trello.com/c/HyUmsbmr (now complete)

Adds a `PendingLogs` table to write logs out to on shutdown. This enables us to not lose logs e.g. because someone's offline or they close the app quickly between runs of the `ElasticsearchPoster`. 

This PR also finalises the ChangeLog for `v4.2.0`, ready for release. 