### PR TITLE
Darts thrown

### DIFF
--- a/.run/Dartzee - All Tests.run.xml
+++ b/.run/Dartzee - All Tests.run.xml
@@ -1,21 +1,27 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Dartzee - E2E" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Dartzee - All Tests" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="screenshotOs" value="linux" />
+          <entry key="updateSnapshots" value="true" />
+        </map>
+      </option>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--tests &quot;e2e.*&quot;" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value=":test" />
+          <option value="test" />
         </list>
       </option>
       <option name="vmOptions" value="" />
     </ExternalSystemSettings>
-    <GradleScriptDebugEnabled>false</GradleScriptDebugEnabled>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/Dartzee.run.xml
+++ b/.run/Dartzee.run.xml
@@ -1,21 +1,21 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Dartzee - E2E" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Dartzee" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--tests &quot;e2e.*&quot;" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value=":test" />
+          <option value="runDev" />
         </list>
       </option>
       <option name="vmOptions" value="" />
     </ExternalSystemSettings>
-    <GradleScriptDebugEnabled>false</GradleScriptDebugEnabled>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/TestGameplayE2E.run.xml
+++ b/.run/TestGameplayE2E.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Dartzee - E2E" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="updateSnapshots" value="true" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--tests &quot;e2e.*&quot;" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>false</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/main/kotlin/dartzee/db/DartEntity.kt
+++ b/src/main/kotlin/dartzee/db/DartEntity.kt
@@ -42,7 +42,7 @@ class DartEntity : AbstractEntity<DartEntity>()
 
     companion object
     {
-        fun factory(dart: Dart, playerId: String, participantId: String, roundNumber: Int, ordinal: Int, startingScore: Int): DartEntity
+        fun factory(dart: Dart, playerId: String, participantId: String, roundNumber: Int, ordinal: Int): DartEntity
         {
             val de = DartEntity()
             de.assignRowId()
@@ -52,7 +52,7 @@ class DartEntity : AbstractEntity<DartEntity>()
             de.score = dart.score
             de.multiplier = dart.multiplier
             de.ordinal = ordinal
-            de.startingScore = startingScore
+            de.startingScore = dart.startingScore
             de.posX = dart.getX()!!
             de.posY = dart.getY()!!
             de.segmentType = dart.segmentType

--- a/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
+++ b/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
@@ -27,7 +27,7 @@ sealed class AbstractPlayerState<S: DartsScorer>
     fun commitRound()
     {
         val entities = dartsThrown.mapIndexed { ix, drt ->
-            DartEntity.factory(drt, pt.playerId, pt.rowId, lastRoundNumber + 1, ix + 1)
+            DartEntity.factory(drt, pt.playerId, pt.rowId, lastRoundNumber, ix + 1)
         }
 
         BulkInserter.insert(entities)

--- a/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
+++ b/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
@@ -1,6 +1,8 @@
 package dartzee.game.state
 
 import dartzee.`object`.Dart
+import dartzee.db.BulkInserter
+import dartzee.db.DartEntity
 import dartzee.db.DartzeeRoundResultEntity
 import dartzee.db.ParticipantEntity
 import dartzee.screen.game.scorer.DartsScorer
@@ -12,6 +14,27 @@ sealed class AbstractPlayerState<S: DartsScorer>
     abstract val scorer: S
     abstract var lastRoundNumber: Int
     abstract val darts: MutableList<List<Dart>>
+    abstract val dartsThrown: MutableList<Dart>
+
+    fun dartThrown(dart: Dart)
+    {
+        dart.participantId = pt.rowId
+        dartsThrown.add(dart)
+    }
+
+    fun resetRound() = dartsThrown.clear()
+
+    fun commitRound()
+    {
+        val entities = dartsThrown.mapIndexed { ix, drt ->
+            DartEntity.factory(drt, pt.playerId, pt.rowId, lastRoundNumber + 1, ix + 1)
+        }
+
+        BulkInserter.insert(entities)
+
+        addDarts(dartsThrown.toList())
+        dartsThrown.clear()
+    }
 
     fun addDarts(darts: List<Dart>)
     {
@@ -23,12 +46,14 @@ sealed class AbstractPlayerState<S: DartsScorer>
 data class DefaultPlayerState<S: DartsScorer>(override val pt: ParticipantEntity,
                                               override val scorer: S,
                                               override var lastRoundNumber: Int = 0,
-                                              override val darts: MutableList<List<Dart>> = mutableListOf()): AbstractPlayerState<S>()
+                                              override val darts: MutableList<List<Dart>> = mutableListOf(),
+                                              override val dartsThrown: MutableList<Dart> = mutableListOf()): AbstractPlayerState<S>()
 
 data class DartzeePlayerState(override val pt: ParticipantEntity,
                               override val scorer: DartsScorerDartzee,
                               override var lastRoundNumber: Int = 0,
                               override val darts: MutableList<List<Dart>> = mutableListOf(),
+                              override val dartsThrown: MutableList<Dart> = mutableListOf(),
                               val roundResults: MutableList<DartzeeRoundResultEntity> = mutableListOf()): AbstractPlayerState<DartsScorerDartzee>()
 {
     fun addRoundResult(result: DartzeeRoundResultEntity)

--- a/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
@@ -619,9 +619,9 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard, PlayerState: Abstra
     }
 
     /**
-     * Loop through the darts thrown, saving them to the database.
+     * Commit round to current player state and the database
      */
-    protected fun saveDartsToDatabase()
+    protected fun commitRound()
     {
         getCurrentPlayerState().commitRound()
     }

--- a/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
@@ -202,8 +202,6 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard, PlayerState: Abstra
         activeScorer = getCurrentScorer()
         selectScorer(activeScorer)
 
-        dartsThrown.clear()
-
         updateVariablesForNewRound()
 
         val lastRoundForThisPlayer = getLastRoundNumber()
@@ -516,7 +514,7 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard, PlayerState: Abstra
     {
         dart.roundNumber = currentRoundNumber
 
-        dartsThrown.add(dart)
+        getCurrentPlayerState().dartThrown(dart)
         activeScorer.addDart(dart)
 
         //We've clicked on the dartboard, so dismiss the slider
@@ -608,7 +606,7 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard, PlayerState: Abstra
         dartboard.clearDarts()
         activeScorer.clearRound(currentRoundNumber)
         activeScorer.updatePlayerResult()
-        dartsThrown.clear()
+        getCurrentPlayerState().resetRound()
 
         //If we're resetting, disable the buttons
         btnConfirm.isEnabled = false
@@ -624,17 +622,7 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard, PlayerState: Abstra
      */
     protected fun saveDartsToDatabase()
     {
-        val pt = getCurrentParticipant()
-        val darts = mutableListOf<DartEntity>()
-        for (i in dartsThrown.indices)
-        {
-            val dart = dartsThrown[i]
-            darts.add(DartEntity.factory(dart, pt.playerId, pt.rowId, currentRoundNumber, i + 1, dart.startingScore))
-        }
-
-        BulkInserter.insert(darts)
-
-        getCurrentPlayerState().addDarts(dartsThrown)
+        getCurrentPlayerState().commitRound()
     }
 
     open fun readyForThrow()

--- a/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsGamePanel.kt
@@ -49,7 +49,6 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard, PlayerState: Abstra
     //Transitive things
     var currentPlayerNumber = 0
     var activeScorer: S = factoryScorer()
-    protected var dartsThrown = ArrayList<Dart>()
     protected var currentRoundNumber = -1
 
     //For AI turns
@@ -105,6 +104,8 @@ abstract class DartsGamePanel<S : DartsScorer, D: Dartboard, PlayerState: Abstra
         val state = getPlayerState(playerNumber)
         state.lastRoundNumber = newRoundNumber
     }
+    fun getDartsThrown() = getCurrentPlayerState().dartsThrown
+    fun dartsThrownCount() = getDartsThrown().size
 
     protected fun addState(playerNumber: Int, state: PlayerState) {
         hmPlayerNumberToState[playerNumber] = state

--- a/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
+++ b/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
@@ -32,7 +32,7 @@ abstract class GamePanelPausable<S : DartsScorerPausable>(parent: AbstractDartsG
             handlePlayerFinish()
         }
 
-        saveDartsToDatabase()
+        commitRound()
 
         currentPlayerNumber = getNextPlayerNumber(currentPlayerNumber)
 

--- a/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
+++ b/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
@@ -26,13 +26,13 @@ abstract class GamePanelPausable<S : DartsScorerPausable>(parent: AbstractDartsG
     {
         activeScorer.updatePlayerResult()
 
-        saveDartsToDatabase()
-
         //This player has finished. The game isn't necessarily over though...
         if (currentPlayerHasFinished())
         {
             handlePlayerFinish()
         }
+
+        saveDartsToDatabase()
 
         currentPlayerNumber = getNextPlayerNumber(currentPlayerNumber)
 

--- a/src/main/kotlin/dartzee/screen/game/dartzee/GamePanelDartzee.kt
+++ b/src/main/kotlin/dartzee/screen/game/dartzee/GamePanelDartzee.kt
@@ -165,7 +165,7 @@ class GamePanelDartzee(parent: AbstractDartsGameScreen,
         disableInputButtons()
         dartboard.clearDarts()
 
-        saveDartsToDatabase()
+        commitRound()
 
         finishRound()
 

--- a/src/main/kotlin/dartzee/screen/game/dartzee/GamePanelDartzee.kt
+++ b/src/main/kotlin/dartzee/screen/game/dartzee/GamePanelDartzee.kt
@@ -50,7 +50,7 @@ class GamePanelDartzee(parent: AbstractDartsGameScreen,
             summaryPanel.ensureReady()
 
             val segmentStatus = summaryPanel.getSegmentStatus()
-            model.throwDartzeeDart(dartsThrown.size, dartboard, segmentStatus)
+            model.throwDartzeeDart(dartsThrownCount(), dartboard, segmentStatus)
         }
     }
 
@@ -105,7 +105,7 @@ class GamePanelDartzee(parent: AbstractDartsGameScreen,
     {
         val segmentStatus = summaryPanel.getSegmentStatus()
         val failedAllRules = segmentStatus.validSegments.isEmpty()
-        return dartsThrown.size == 3 || failedAllRules
+        return dartsThrownCount() == 3 || failedAllRules
     }
 
     override fun shouldAIStop() = false
@@ -130,7 +130,7 @@ class GamePanelDartzee(parent: AbstractDartsGameScreen,
     private fun updateCarousel()
     {
         val ruleResults = getCurrentPlayerState().roundResults
-        summaryPanel.update(ruleResults, dartsThrown, lastRoundScore, currentRoundNumber)
+        summaryPanel.update(ruleResults, getDartsThrown(), lastRoundScore, currentRoundNumber)
     }
 
     /**
@@ -140,7 +140,7 @@ class GamePanelDartzee(parent: AbstractDartsGameScreen,
     {
         if (isScoringRound())
         {
-            completeRound(factoryHighScoreResult(dartsThrown))
+            completeRound(factoryHighScoreResult(getDartsThrown()))
         }
         else
         {
@@ -188,7 +188,7 @@ class GamePanelDartzee(parent: AbstractDartsGameScreen,
 
     override fun hoverChanged(segmentStatus: SegmentStatus)
     {
-        if (dartsThrown.size < 3)
+        if (dartsThrownCount() < 3)
         {
             dartboard.refreshValidSegments(segmentStatus)
         }

--- a/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
@@ -27,7 +27,7 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
 
     private fun getScoreForMostRecentDart() : Int
     {
-        val lastDart = dartsThrown.last()
+        val lastDart = getDartsThrown().last()
 
         val targetHole = currentRoundNumber
         return lastDart.getGolfScore(targetHole)
@@ -36,7 +36,7 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
     override fun doAiTurn(model: DartsAiModel)
     {
         val targetHole = currentRoundNumber
-        val dartNo = dartsThrown.size + 1
+        val dartNo = dartsThrownCount() + 1
         model.throwGolfDart(targetHole, dartNo, dartboard)
     }
 
@@ -56,7 +56,8 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
 
     override fun shouldStopAfterDartThrown(): Boolean
     {
-        if (dartsThrown.size == 3)
+        val dartsThrownCount = dartsThrownCount()
+        if (dartsThrownCount == 3)
         {
             return true
         }
@@ -68,10 +69,8 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
         }
         else
         {
-            val noDarts = dartsThrown.size
-
             val model = getCurrentPlayerStrategy()
-            val stopThreshold = model.getStopThresholdForDartNo(noDarts)
+            val stopThreshold = model.getStopThresholdForDartNo(dartsThrownCount)
 
             return score <= stopThreshold
         }
@@ -90,7 +89,8 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
 
     fun unlockAchievements()
     {
-        val dartsRisked = dartsThrown - dartsThrown.last()
+        val lastDart = getDartsThrown().last()
+        val dartsRisked = getDartsThrown() - lastDart
         val pointsRisked = dartsRisked.map{ 5 - it.getGolfScore(currentRoundNumber) }.sum()
 
         if (pointsRisked > 0)
@@ -98,7 +98,6 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
             AchievementEntity.incrementAchievement(ACHIEVEMENT_REF_GOLF_POINTS_RISKED, getCurrentPlayerId(), gameEntity.rowId, pointsRisked)
         }
 
-        val lastDart = dartsThrown.last()
         if (lastDart.getGolfScore(currentRoundNumber) == 1
          && retrieveAchievementForDetail(ACHIEVEMENT_REF_GOLF_COURSE_MASTER, getCurrentPlayerId(), "$currentRoundNumber") == null)
         {

--- a/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
@@ -78,11 +78,10 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
 
     override fun saveDartsAndProceed()
     {
+        unlockAchievements()
         saveDartsToDatabase()
 
         activeScorer.finaliseRoundScore()
-
-        unlockAchievements()
 
         finishRound()
     }

--- a/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
@@ -79,7 +79,7 @@ open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, tota
     override fun saveDartsAndProceed()
     {
         unlockAchievements()
-        saveDartsToDatabase()
+        commitRound()
 
         activeScorer.finaliseRoundScore()
 

--- a/src/main/kotlin/dartzee/screen/game/rtc/GamePanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/rtc/GamePanelRoundTheClock.kt
@@ -131,12 +131,7 @@ open class GamePanelRoundTheClock(parent: AbstractDartsGameScreen, game: GameEnt
             return true
         }
 
-        var allHits = true
-        for (dart in getDartsThrown())
-        {
-            allHits = allHits and dart.hitClockTarget(config.clockType)
-        }
-
+        val allHits = getDartsThrown().all { it.hitClockTarget(config.clockType) }
         return dartsThrownCount() == 3 && !allHits
 
     }

--- a/src/main/kotlin/dartzee/screen/game/rtc/GamePanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/rtc/GamePanelRoundTheClock.kt
@@ -98,12 +98,12 @@ open class GamePanelRoundTheClock(parent: AbstractDartsGameScreen, game: GameEnt
         {
             activeScorer.incrementCurrentClockTarget()
 
-            if (dartsThrown.size == 4)
+            if (dartsThrownCount() == 4)
             {
                 dartboard.doForsyth()
             }
         }
-        else if (dartsThrown.size == 4)
+        else if (dartsThrownCount() == 4)
         {
             dartboard.doBadLuck()
         }
@@ -115,12 +115,12 @@ open class GamePanelRoundTheClock(parent: AbstractDartsGameScreen, game: GameEnt
 
     override fun shouldAnimateMiss(dart: Dart): Boolean
     {
-        return dartsThrown.size < 4
+        return dartsThrownCount() < 4
     }
 
     override fun shouldStopAfterDartThrown(): Boolean
     {
-        if (dartsThrown.size == 4)
+        if (dartsThrownCount() == 4)
         {
             return true
         }
@@ -132,12 +132,12 @@ open class GamePanelRoundTheClock(parent: AbstractDartsGameScreen, game: GameEnt
         }
 
         var allHits = true
-        for (dart in dartsThrown)
+        for (dart in getDartsThrown())
         {
             allHits = allHits and dart.hitClockTarget(config.clockType)
         }
 
-        return dartsThrown.size == 3 && !allHits
+        return dartsThrownCount() == 3 && !allHits
 
     }
 
@@ -148,7 +148,7 @@ open class GamePanelRoundTheClock(parent: AbstractDartsGameScreen, game: GameEnt
 
     override fun saveDartsAndProceed()
     {
-        if (dartsThrown.size == 4 && dartsThrown.last().hitClockTarget(config.clockType))
+        if (dartsThrownCount() == 4 && getDartsThrown().last().hitClockTarget(config.clockType))
         {
             AchievementEntity.incrementAchievement(ACHIEVEMENT_REF_CLOCK_BRUCEY_BONUSES, getCurrentPlayerId(), getGameId())
         }
@@ -161,7 +161,7 @@ open class GamePanelRoundTheClock(parent: AbstractDartsGameScreen, game: GameEnt
     fun updateBestStreakAchievement()
     {
         var currentStreak = hmPlayerNumberToCurrentStreak.getCount(currentPlayerNumber)
-        dartsThrown.forEach {
+        getDartsThrown().forEach {
             if (it.hitClockTarget(config.clockType))
             {
                 currentStreak++

--- a/src/main/kotlin/dartzee/stats/GameWrapper.kt
+++ b/src/main/kotlin/dartzee/stats/GameWrapper.kt
@@ -368,7 +368,7 @@ class GameWrapper(val localId: Long, val gameParams: String, val dtStart: Timest
             val darts = hmRoundNumberToDarts[i]!!
 
             darts.forEachIndexed { ix, drt ->
-                val de = DartEntity.factory(drt, player.rowId, pt.rowId, i, ix+1, drt.startingScore)
+                val de = DartEntity.factory(drt, player.rowId, pt.rowId, i, ix+1)
                 dartEntities.add(de)
             }
         }

--- a/src/test/kotlin/dartzee/ai/TestDartsSimulationGolf.kt
+++ b/src/test/kotlin/dartzee/ai/TestDartsSimulationGolf.kt
@@ -36,7 +36,7 @@ class TestDartsSimulationGolf: AbstractTest()
         val dartboard = makeTestDartboard()
 
         val hmDartNoToStopThreshold = mutableMapOf(1 to 2, 2 to 3)
-        val model = predictableGolfModel(dartboard, hmDartNoToStopThreshold) { hole, dartNo ->
+        val model = predictableGolfModel(dartboard, hmDartNoToStopThreshold) { hole, _ ->
             when
             {
                 hole == 1 -> ScoreAndSegmentType(1, SegmentType.TREBLE)

--- a/src/test/kotlin/dartzee/db/TestDartEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartEntity.kt
@@ -16,17 +16,18 @@ class TestDartEntity: AbstractEntityTest<DartEntity>()
     fun `Should factory with the correct values`()
     {
         val dart = Dart(20, 3, Point(5, 5), SegmentType.TREBLE)
+        dart.startingScore = 301
         val playerId = randomGuid()
         val participantId = randomGuid()
 
-        val de = DartEntity.factory(dart, playerId, participantId, 5, 1, 501)
+        val de = DartEntity.factory(dart, playerId, participantId, 5, 1)
 
         de.rowId shouldNotBe ""
         de.playerId shouldBe playerId
         de.participantId shouldBe participantId
         de.roundNumber shouldBe 5
         de.ordinal shouldBe 1
-        de.startingScore shouldBe 501
+        de.startingScore shouldBe 301
         de.score shouldBe 20
         de.multiplier shouldBe 3
         de.posX shouldBe 5

--- a/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
+++ b/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
@@ -97,7 +97,7 @@ fun makeDartzeePlayerState(name: String = "Bob",
     val pt = insertParticipant(playerId = p.rowId)
 
     val resultEntities = makeRoundResultEntities(*roundResults.toTypedArray())
-    return DartzeePlayerState(pt, scorer, lastRoundNumber, dartsThrown.toMutableList(), resultEntities.toMutableList())
+    return DartzeePlayerState(pt, scorer, lastRoundNumber, dartsThrown.toMutableList(), mutableListOf(), resultEntities.toMutableList())
 }
 
 fun makeDartzeeScorer(firstRound: List<Dart> = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1))): DartsScorerDartzee

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelGolf.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelGolf.kt
@@ -169,8 +169,8 @@ class TestGamePanelGolf: AbstractTest()
 
         fun setDartsThrown(dartsThrown: List<Dart>)
         {
-            this.dartsThrown.clear()
-            this.dartsThrown.addAll(dartsThrown)
+            getCurrentPlayerState().resetRound()
+            dartsThrown.forEach { getCurrentPlayerState().dartThrown(it) }
         }
     }
 }

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelRoundTheClock.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelRoundTheClock.kt
@@ -140,7 +140,8 @@ class TestGamePanelRoundTheClock: AbstractTest()
 
         fun setDartsThrown(dartsThrown: List<Dart>)
         {
-            this.dartsThrown.addAll(dartsThrown)
+            getCurrentPlayerState().resetRound()
+            dartsThrown.forEach { getCurrentPlayerState().dartThrown(it) }
         }
     }
 }

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelX01.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelX01.kt
@@ -149,8 +149,8 @@ class TestGamePanelX01: AbstractTest()
 
         fun setDartsThrown(dartsThrown: List<Dart>)
         {
-            this.dartsThrown.clear()
-            this.dartsThrown.addAll(dartsThrown)
+            getCurrentPlayerState().resetRound()
+            dartsThrown.forEach { getCurrentPlayerState().dartThrown(it) }
         }
     }
 }

--- a/src/test/kotlin/e2e/SimulationHelpers.kt
+++ b/src/test/kotlin/e2e/SimulationHelpers.kt
@@ -7,6 +7,6 @@ import dartzee.screen.stats.player.PlayerStatisticsScreen
 
 fun awaitStatisticsScreen(): PlayerStatisticsScreen
 {
-    awaitCondition { getWindow { it.findChild<PlayerStatisticsScreen>() != null }?.isVisible ?: false }
+    awaitCondition(20000) { getWindow { it.findChild<PlayerStatisticsScreen>() != null }?.isVisible == true }
     return getWindow { it.findChild<PlayerStatisticsScreen>() != null }!!.getChild()
 }


### PR DESCRIPTION
Refactor `dartsThrown` into PlayerState - this will be needed if we want scorers to rerender themselves based on a state listener. 
It also allows for the whole "commit" logic to move into the state too.