### PR TITLE
Pull scorers back out of state

### DIFF
--- a/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
+++ b/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
@@ -5,13 +5,11 @@ import dartzee.db.BulkInserter
 import dartzee.db.DartEntity
 import dartzee.db.DartzeeRoundResultEntity
 import dartzee.db.ParticipantEntity
-import dartzee.screen.game.scorer.DartsScorer
-import dartzee.screen.game.scorer.DartsScorerDartzee
+import dartzee.utils.sumScore
 
-sealed class AbstractPlayerState<S: DartsScorer>
+sealed class AbstractPlayerState
 {
     abstract val pt: ParticipantEntity
-    abstract val scorer: S
     abstract var lastRoundNumber: Int
     abstract val darts: MutableList<List<Dart>>
     abstract val dartsThrown: MutableList<Dart>
@@ -43,21 +41,27 @@ sealed class AbstractPlayerState<S: DartsScorer>
     }
 }
 
-data class DefaultPlayerState<S: DartsScorer>(override val pt: ParticipantEntity,
-                                              override val scorer: S,
-                                              override var lastRoundNumber: Int = 0,
-                                              override val darts: MutableList<List<Dart>> = mutableListOf(),
-                                              override val dartsThrown: MutableList<Dart> = mutableListOf()): AbstractPlayerState<S>()
+data class DefaultPlayerState(override val pt: ParticipantEntity,
+                              override var lastRoundNumber: Int = 0,
+                              override val darts: MutableList<List<Dart>> = mutableListOf(),
+                              override val dartsThrown: MutableList<Dart> = mutableListOf()): AbstractPlayerState()
 
 data class DartzeePlayerState(override val pt: ParticipantEntity,
-                              override val scorer: DartsScorerDartzee,
                               override var lastRoundNumber: Int = 0,
                               override val darts: MutableList<List<Dart>> = mutableListOf(),
                               override val dartsThrown: MutableList<Dart> = mutableListOf(),
-                              val roundResults: MutableList<DartzeeRoundResultEntity> = mutableListOf()): AbstractPlayerState<DartsScorerDartzee>()
+                              val roundResults: MutableList<DartzeeRoundResultEntity> = mutableListOf()): AbstractPlayerState()
 {
     fun addRoundResult(result: DartzeeRoundResultEntity)
     {
         roundResults.add(result)
     }
+
+    fun getCumulativeScore(roundNumber: Int): Int
+    {
+        val roundResultTotal = roundResults.filter { it.roundNumber <= roundNumber }.sumBy { it.score }
+        return roundResultTotal + sumScore(darts.first())
+    }
+
+    fun getPeakScore() = (1..lastRoundNumber).map(::getCumulativeScore).max()
 }

--- a/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
+++ b/src/main/kotlin/dartzee/game/state/DefaultPlayerState.kt
@@ -57,11 +57,10 @@ data class DartzeePlayerState(override val pt: ParticipantEntity,
         roundResults.add(result)
     }
 
+    fun getPeakScore() = (1..lastRoundNumber).map(::getCumulativeScore).max()
     fun getCumulativeScore(roundNumber: Int): Int
     {
         val roundResultTotal = roundResults.filter { it.roundNumber <= roundNumber }.sumBy { it.score }
         return roundResultTotal + sumScore(darts.first())
     }
-
-    fun getPeakScore() = (1..lastRoundNumber).map(::getCumulativeScore).max()
 }

--- a/src/main/kotlin/dartzee/screen/game/AbstractGameStatisticsPanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/AbstractGameStatisticsPanel.kt
@@ -16,7 +16,7 @@ import javax.swing.table.DefaultTableModel
 /**
  * Shows statistics for each player in a particular game, based on the PlayerStates
  */
-abstract class AbstractGameStatisticsPanel<PlayerState: AbstractPlayerState<*>>: JPanel()
+abstract class AbstractGameStatisticsPanel<PlayerState: AbstractPlayerState>: JPanel()
 {
     protected val playerNamesOrdered = mutableListOf<String>()
     protected var participants: List<ParticipantEntity> = emptyList()

--- a/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/DartsMatchScreen.kt
@@ -16,7 +16,7 @@ import javax.swing.SwingConstants
 import javax.swing.event.ChangeEvent
 import javax.swing.event.ChangeListener
 
-abstract class DartsMatchScreen<PlayerState: AbstractPlayerState<*>>(private val matchPanel: MatchSummaryPanel<PlayerState>,
+abstract class DartsMatchScreen<PlayerState: AbstractPlayerState>(private val matchPanel: MatchSummaryPanel<PlayerState>,
                                                                      val match: DartsMatchEntity,
                                                                      players: List<PlayerEntity>):
         AbstractDartsGameScreen(match.getPlayerCount(), match.gameType), ChangeListener

--- a/src/main/kotlin/dartzee/screen/game/GamePanelFixedLength.kt
+++ b/src/main/kotlin/dartzee/screen/game/GamePanelFixedLength.kt
@@ -7,7 +7,7 @@ import dartzee.screen.game.scorer.DartsScorer
 import dartzee.utils.doesHighestWin
 import dartzee.utils.setFinishingPositions
 
-abstract class GamePanelFixedLength<S : DartsScorer, D: Dartboard, PlayerState: AbstractPlayerState<S>>(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int):
+abstract class GamePanelFixedLength<S : DartsScorer, D: Dartboard, PlayerState: AbstractPlayerState>(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int):
         DartsGamePanel<S, D, PlayerState>(parent, game, totalPlayers)
 {
     abstract val totalRounds: Int

--- a/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
+++ b/src/main/kotlin/dartzee/screen/game/GamePanelPausable.kt
@@ -10,7 +10,7 @@ import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
 import dartzee.utils.PreferenceUtil
 
 abstract class GamePanelPausable<S : DartsScorerPausable>(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int):
-        DartsGamePanel<S, Dartboard, DefaultPlayerState<S>>(parent, game, totalPlayers)
+        DartsGamePanel<S, Dartboard, DefaultPlayerState>(parent, game, totalPlayers)
 {
     private var aiShouldPause = false
 
@@ -20,7 +20,7 @@ abstract class GamePanelPausable<S : DartsScorerPausable>(parent: AbstractDartsG
     abstract fun currentPlayerHasFinished(): Boolean
 
     override fun factoryDartboard() = Dartboard()
-    override fun factoryState(pt: ParticipantEntity, scorer: S) = DefaultPlayerState(pt, scorer)
+    override fun factoryState(pt: ParticipantEntity) = DefaultPlayerState(pt)
 
     override fun saveDartsAndProceed()
     {

--- a/src/main/kotlin/dartzee/screen/game/MatchSummaryPanel.kt
+++ b/src/main/kotlin/dartzee/screen/game/MatchSummaryPanel.kt
@@ -16,7 +16,7 @@ import javax.swing.JPanel
 /**
  * The first tab displayed for any match. Provides a summary of the players' overall scores with (hopefully) nice graphs and stuff
  */
-class MatchSummaryPanel<PlayerState: AbstractPlayerState<*>>(val match: DartsMatchEntity,
+class MatchSummaryPanel<PlayerState: AbstractPlayerState>(val match: DartsMatchEntity,
                                                              private val statsPanel: AbstractGameStatisticsPanel<PlayerState>) :
     PanelWithScorers<MatchScorer>(), ActionListener
 {

--- a/src/main/kotlin/dartzee/screen/game/dartzee/GamePanelDartzee.kt
+++ b/src/main/kotlin/dartzee/screen/game/dartzee/GamePanelDartzee.kt
@@ -36,7 +36,7 @@ class GamePanelDartzee(parent: AbstractDartsGameScreen,
     }
 
     override fun factoryDartboard() = DartzeeDartboard()
-    override fun factoryState(pt: ParticipantEntity, scorer: DartsScorerDartzee) = DartzeePlayerState(pt, scorer)
+    override fun factoryState(pt: ParticipantEntity) = DartzeePlayerState(pt)
 
     override fun doAiTurn(model: DartsAiModel)
     {

--- a/src/main/kotlin/dartzee/screen/game/dartzee/GameStatisticsPanelDartzee.kt
+++ b/src/main/kotlin/dartzee/screen/game/dartzee/GameStatisticsPanelDartzee.kt
@@ -30,7 +30,7 @@ open class GameStatisticsPanelDartzee: AbstractGameStatisticsPanel<DartzeePlayer
     private fun getPeakScore(playerName: String): Any?
     {
         val states = hmPlayerToStates[playerName] ?: return null
-        return states.mapNotNull { it.scorer.getMaxScoreSoFar() }.max()
+        return states.mapNotNull { it.getPeakScore() }.max()
     }
 
     private fun getScoreRow(desc: String, f: (i: List<Int>) -> Number) = prepareRow(desc) { playerName ->

--- a/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/golf/GamePanelGolf.kt
@@ -17,13 +17,13 @@ import dartzee.screen.game.GamePanelFixedLength
 import dartzee.screen.game.scorer.DartsScorerGolf
 
 open class GamePanelGolf(parent: AbstractDartsGameScreen, game: GameEntity, totalPlayers: Int) :
-        GamePanelFixedLength<DartsScorerGolf, Dartboard, DefaultPlayerState<DartsScorerGolf>>(parent, game, totalPlayers)
+        GamePanelFixedLength<DartsScorerGolf, Dartboard, DefaultPlayerState>(parent, game, totalPlayers)
 {
     //Number of rounds - 9 holes or 18?
     override val totalRounds = Integer.parseInt(game.gameParams)
 
     override fun factoryDartboard() = Dartboard()
-    override fun factoryState(pt: ParticipantEntity, scorer: DartsScorerGolf) = DefaultPlayerState(pt, scorer)
+    override fun factoryState(pt: ParticipantEntity) = DefaultPlayerState(pt)
 
     private fun getScoreForMostRecentDart() : Int
     {

--- a/src/main/kotlin/dartzee/screen/game/golf/GameStatisticsPanelGolf.kt
+++ b/src/main/kotlin/dartzee/screen/game/golf/GameStatisticsPanelGolf.kt
@@ -4,9 +4,8 @@ import dartzee.`object`.Dart
 import dartzee.core.util.MathsUtil
 import dartzee.game.state.DefaultPlayerState
 import dartzee.screen.game.AbstractGameStatisticsPanel
-import dartzee.screen.game.scorer.DartsScorerGolf
 
-open class GameStatisticsPanelGolf: AbstractGameStatisticsPanel<DefaultPlayerState<DartsScorerGolf>>()
+open class GameStatisticsPanelGolf: AbstractGameStatisticsPanel<DefaultPlayerState>()
 {
     override fun getRankedRowsHighestWins() = listOf("Points Improved")
     override fun getRankedRowsLowestWins() = listOf("Best Hole", "Avg. Hole", "Worst Hole", "Miss %", "Points Squandered")

--- a/src/main/kotlin/dartzee/screen/game/golf/GolfMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/golf/GolfMatchScreen.kt
@@ -7,10 +7,9 @@ import dartzee.game.state.DefaultPlayerState
 import dartzee.screen.game.AbstractDartsGameScreen
 import dartzee.screen.game.DartsMatchScreen
 import dartzee.screen.game.MatchSummaryPanel
-import dartzee.screen.game.scorer.DartsScorerGolf
 
 class GolfMatchScreen(match: DartsMatchEntity, players: List<PlayerEntity>):
-    DartsMatchScreen<DefaultPlayerState<DartsScorerGolf>>(MatchSummaryPanel(match, MatchStatisticsPanelGolf()), match, players)
+    DartsMatchScreen<DefaultPlayerState>(MatchSummaryPanel(match, MatchStatisticsPanelGolf()), match, players)
 {
     override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity) = GamePanelGolf(parent, game, match.getPlayerCount())
 }

--- a/src/main/kotlin/dartzee/screen/game/rtc/GameStatisticsPanelRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/rtc/GameStatisticsPanelRoundTheClock.kt
@@ -6,10 +6,9 @@ import dartzee.core.util.maxOrZero
 import dartzee.game.RoundTheClockConfig
 import dartzee.game.state.DefaultPlayerState
 import dartzee.screen.game.AbstractGameStatisticsPanel
-import dartzee.screen.game.scorer.DartsScorerRoundTheClock
 import dartzee.utils.getLongestStreak
 
-open class GameStatisticsPanelRoundTheClock(gameParams: String): AbstractGameStatisticsPanel<DefaultPlayerState<DartsScorerRoundTheClock>>()
+open class GameStatisticsPanelRoundTheClock(gameParams: String): AbstractGameStatisticsPanel<DefaultPlayerState>()
 {
     private val config = RoundTheClockConfig.fromJson(gameParams)
 

--- a/src/main/kotlin/dartzee/screen/game/rtc/RoundTheClockMatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/rtc/RoundTheClockMatchScreen.kt
@@ -7,10 +7,9 @@ import dartzee.game.state.DefaultPlayerState
 import dartzee.screen.game.AbstractDartsGameScreen
 import dartzee.screen.game.DartsMatchScreen
 import dartzee.screen.game.MatchSummaryPanel
-import dartzee.screen.game.scorer.DartsScorerRoundTheClock
 
 class RoundTheClockMatchScreen(match: DartsMatchEntity, players: List<PlayerEntity>):
-    DartsMatchScreen<DefaultPlayerState<DartsScorerRoundTheClock>>(MatchSummaryPanel(match, MatchStatisticsPanelRoundTheClock(match.gameParams)), match, players)
+    DartsMatchScreen<DefaultPlayerState>(MatchSummaryPanel(match, MatchStatisticsPanelRoundTheClock(match.gameParams)), match, players)
 {
     override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity) = GamePanelRoundTheClock(parent, game, match.getPlayerCount())
 }

--- a/src/main/kotlin/dartzee/screen/game/scorer/DartsScorerDartzee.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/DartsScorerDartzee.kt
@@ -50,7 +50,7 @@ class DartsScorerDartzee(private val parent: GamePanelDartzee): DartsScorer(), M
         tableScores.repaint()
     }
 
-    fun getMaxScoreSoFar() = model.getColumnValues(SCORE_COLUMN).filterIsInstance<Int>().max()
+    private fun getMaxScoreSoFar() = model.getColumnValues(SCORE_COLUMN).filterIsInstance<Int>().max()
 
     override fun mouseReleased(e: MouseEvent?)
     {

--- a/src/main/kotlin/dartzee/screen/game/x01/GameStatisticsPanelX01.kt
+++ b/src/main/kotlin/dartzee/screen/game/x01/GameStatisticsPanelX01.kt
@@ -21,7 +21,7 @@ import javax.swing.JPanel
 /**
  * Shows running stats for X01 games - three-dart average, checkout % etc.
  */
-open class GameStatisticsPanelX01(gameParams: String): AbstractGameStatisticsPanel<DefaultPlayerState<DartsScorerX01>>(), PropertyChangeListener
+open class GameStatisticsPanelX01(gameParams: String): AbstractGameStatisticsPanel<DefaultPlayerState>(), PropertyChangeListener
 {
     private val panel = JPanel()
     private val lblSetupThreshold = JLabel("Setup Threshold")

--- a/src/main/kotlin/dartzee/screen/game/x01/X01MatchScreen.kt
+++ b/src/main/kotlin/dartzee/screen/game/x01/X01MatchScreen.kt
@@ -7,10 +7,9 @@ import dartzee.game.state.DefaultPlayerState
 import dartzee.screen.game.AbstractDartsGameScreen
 import dartzee.screen.game.DartsMatchScreen
 import dartzee.screen.game.MatchSummaryPanel
-import dartzee.screen.game.scorer.DartsScorerX01
 
 class X01MatchScreen(match: DartsMatchEntity, players: List<PlayerEntity>):
-    DartsMatchScreen<DefaultPlayerState<DartsScorerX01>>(MatchSummaryPanel(match, MatchStatisticsPanelX01(match.gameParams)), match, players)
+    DartsMatchScreen<DefaultPlayerState>(MatchSummaryPanel(match, MatchStatisticsPanelX01(match.gameParams)), match, players)
 {
     override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity) = GamePanelX01(parent, game, match.getPlayerCount())
 }

--- a/src/test/kotlin/dartzee/game/state/TestAbstractPlayerState.kt
+++ b/src/test/kotlin/dartzee/game/state/TestAbstractPlayerState.kt
@@ -5,11 +5,9 @@ import dartzee.`object`.SegmentType
 import dartzee.db.DartEntity
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertParticipant
-import dartzee.screen.game.scorer.DartsScorer
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.shouldBe
-import io.mockk.mockk
 import org.junit.Test
 import java.awt.Point
 
@@ -18,7 +16,7 @@ class TestAbstractPlayerState: AbstractTest()
     @Test
     fun `it should take a copy of the darts that are added`()
     {
-        val state = DefaultPlayerState(insertParticipant(), mockk<DartsScorer>())
+        val state = DefaultPlayerState(insertParticipant())
         val darts = mutableListOf(Dart(20, 1))
 
         state.addDarts(darts)
@@ -31,7 +29,7 @@ class TestAbstractPlayerState: AbstractTest()
     fun `It should populate the darts with the ParticipantId`()
     {
         val pt = insertParticipant()
-        val state = DefaultPlayerState(pt, mockk<DartsScorer>())
+        val state = DefaultPlayerState(pt)
 
         val dart = Dart(20, 1)
         dart.participantId shouldBe ""
@@ -44,7 +42,7 @@ class TestAbstractPlayerState: AbstractTest()
     @Test
     fun `Should support resetting the currently thrown darts`()
     {
-        val state = DefaultPlayerState(insertParticipant(), mockk<DartsScorer>())
+        val state = DefaultPlayerState(insertParticipant())
 
         state.dartThrown(Dart(20, 1))
         state.dartsThrown.shouldContainExactly(Dart(20, 1))
@@ -61,7 +59,7 @@ class TestAbstractPlayerState: AbstractTest()
         val dartTwo = Dart(5, 1, Point(40, 45), SegmentType.OUTER_SINGLE)
         val dartThree = Dart(1, 1, Point(60, 45), SegmentType.OUTER_SINGLE)
 
-        val state = DefaultPlayerState(pt, mockk<DartsScorer>())
+        val state = DefaultPlayerState(pt)
         state.dartThrown(dartOne)
         state.dartThrown(dartTwo)
         state.dartThrown(dartThree)

--- a/src/test/kotlin/dartzee/game/state/TestDartzeePlayerState.kt
+++ b/src/test/kotlin/dartzee/game/state/TestDartzeePlayerState.kt
@@ -1,0 +1,29 @@
+package dartzee.game.state
+
+import dartzee.`object`.Dart
+import dartzee.dartzee.DartzeeRoundResult
+import dartzee.helper.AbstractTest
+import dartzee.helper.makeDartzeePlayerState
+import io.kotlintest.shouldBe
+import org.junit.Test
+
+class TestDartzeePlayerState: AbstractTest()
+{
+    @Test
+    fun `Should correctly calculate the cumulative score for a given round`()
+    {
+        val scoringRound = listOf(Dart(20, 1), Dart(7, 3), Dart(19, 1))
+        val resultTwo = DartzeeRoundResult(1, false, -30)
+        val resultThree = DartzeeRoundResult(7, true, 75)
+        val resultFour = DartzeeRoundResult(2, false, -52)
+        val resultFive = DartzeeRoundResult(3, true, 50)
+        val state = makeDartzeePlayerState(dartsThrown = listOf(scoringRound), roundResults = listOf(resultTwo, resultThree, resultFour, resultFive))
+
+        state.getCumulativeScore(1) shouldBe 60
+        state.getCumulativeScore(2) shouldBe 30
+        state.getCumulativeScore(3) shouldBe 105
+        state.getCumulativeScore(4) shouldBe 53
+        state.getCumulativeScore(5) shouldBe 103
+        state.getPeakScore() shouldBe 105
+    }
+}

--- a/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
+++ b/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
@@ -14,10 +14,7 @@ import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
 import dartzee.db.DartzeeRoundResultEntity
 import dartzee.game.state.DartzeePlayerState
 import dartzee.screen.game.dartzee.SegmentStatus
-import dartzee.screen.game.scorer.DartsScorerDartzee
-import dartzee.utils.factoryHighScoreResult
 import dartzee.utils.getAllPossibleSegments
-import io.mockk.mockk
 
 val twoBlackOneWhite = makeDartzeeRuleDto(makeColourRule(black = true), makeColourRule(black = true), makeColourRule(white = true),
         inOrder = false,
@@ -88,7 +85,6 @@ fun makeRoundResultEntities(vararg roundResult: DartzeeRoundResult): List<Dartze
 }
 
 fun makeDartzeePlayerState(name: String = "Bob",
-                           scorer: DartsScorerDartzee = DartsScorerDartzee(mockk(relaxed = true)),
                            dartsThrown: List<List<Dart>> = emptyList(),
                            roundResults: List<DartzeeRoundResult> = emptyList(),
                            lastRoundNumber: Int = roundResults.size): DartzeePlayerState
@@ -97,17 +93,7 @@ fun makeDartzeePlayerState(name: String = "Bob",
     val pt = insertParticipant(playerId = p.rowId)
 
     val resultEntities = makeRoundResultEntities(*roundResults.toTypedArray())
-    return DartzeePlayerState(pt, scorer, lastRoundNumber, dartsThrown.toMutableList(), mutableListOf(), resultEntities.toMutableList())
-}
-
-fun makeDartzeeScorer(firstRound: List<Dart> = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1))): DartsScorerDartzee
-{
-    val scorer = DartsScorerDartzee(mockk(relaxed = true))
-    scorer.init(insertPlayer())
-    firstRound.forEach { scorer.addDart(it) }
-    scorer.setResult(factoryHighScoreResult(firstRound))
-
-    return scorer
+    return DartzeePlayerState(pt, lastRoundNumber, dartsThrown.toMutableList(), mutableListOf(), resultEntities.toMutableList())
 }
 
 fun makeSegmentStatus(scoringSegments: List<DartboardSegment> = getAllPossibleSegments(),

--- a/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
+++ b/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
@@ -81,7 +81,7 @@ fun getInnerSegments() = getAllPossibleSegments().filter { (it.score == 25 && !i
 
 fun makeRoundResultEntities(vararg roundResult: DartzeeRoundResult): List<DartzeeRoundResultEntity> {
     val pt = insertParticipant()
-    return roundResult.mapIndexed { index, result -> DartzeeRoundResultEntity.factoryAndSave(result, pt, index + 1) }
+    return roundResult.mapIndexed { index, result -> DartzeeRoundResultEntity.factoryAndSave(result, pt, index + 2) }
 }
 
 fun makeDartzeePlayerState(name: String = "Bob",

--- a/src/test/kotlin/dartzee/helper/TestFactory.kt
+++ b/src/test/kotlin/dartzee/helper/TestFactory.kt
@@ -5,8 +5,6 @@ import dartzee.`object`.SegmentType
 import dartzee.db.ParticipantEntity
 import dartzee.db.PlayerEntity
 import dartzee.game.state.DefaultPlayerState
-import dartzee.screen.game.scorer.DartsScorer
-import io.mockk.mockk
 import java.awt.Point
 
 fun factoryClockHit(score: Int, multiplier: Int = 1): Dart
@@ -51,19 +49,19 @@ fun makeX01Rounds(startingScore: Int = 501, vararg darts: Dart): List<List<Dart>
     return darts.toList().chunked(3)
 }
 
-inline fun <reified S: DartsScorer> makeDefaultPlayerState(player: PlayerEntity = insertPlayer(),
+fun makeDefaultPlayerState(player: PlayerEntity = insertPlayer(),
                            participant: ParticipantEntity = insertParticipant(playerId = player.rowId),
                            dartsThrown: List<Dart> = listOf(makeDart()),
-                           lastRoundNumber: Int = dartsThrown.size): DefaultPlayerState<S>
+                           lastRoundNumber: Int = dartsThrown.size): DefaultPlayerState
 {
-    return DefaultPlayerState(participant, mockk(relaxed = true), lastRoundNumber, mutableListOf(dartsThrown))
+    return DefaultPlayerState(participant, lastRoundNumber, mutableListOf(dartsThrown))
 }
 
-inline fun <reified S: DartsScorer> makeDefaultPlayerStateWithRounds(player: PlayerEntity = insertPlayer(),
-                                                           participant: ParticipantEntity = insertParticipant(playerId = player.rowId),
-                                                           dartsThrown: List<List<Dart>> = emptyList(),
-                                                           lastRoundNumber: Int = dartsThrown.size): DefaultPlayerState<S>
+fun makeDefaultPlayerStateWithRounds(player: PlayerEntity = insertPlayer(),
+                                     participant: ParticipantEntity = insertParticipant(playerId = player.rowId),
+                                     dartsThrown: List<List<Dart>> = emptyList(),
+                                     lastRoundNumber: Int = dartsThrown.size): DefaultPlayerState
 {
     dartsThrown.flatten().forEach { it.participantId = participant.rowId }
-    return DefaultPlayerState(participant, mockk(relaxed = true), lastRoundNumber, dartsThrown.toMutableList())
+    return DefaultPlayerState(participant, lastRoundNumber, dartsThrown.toMutableList())
 }

--- a/src/test/kotlin/dartzee/screen/game/AbstractGameStatisticsPanelTest.kt
+++ b/src/test/kotlin/dartzee/screen/game/AbstractGameStatisticsPanelTest.kt
@@ -8,7 +8,7 @@ import io.kotlintest.matchers.collections.shouldContainAll
 import io.kotlintest.shouldBe
 import org.junit.Test
 
-abstract class AbstractGameStatisticsPanelTest<PlayerState: AbstractPlayerState<*>, S: AbstractGameStatisticsPanel<PlayerState>>: AbstractTest()
+abstract class AbstractGameStatisticsPanelTest<PlayerState: AbstractPlayerState, S: AbstractGameStatisticsPanel<PlayerState>>: AbstractTest()
 {
     abstract fun factoryStatsPanel(): S
     abstract fun makePlayerState(): PlayerState

--- a/src/test/kotlin/dartzee/screen/game/TestAbstractGameStatisticsPanel.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestAbstractGameStatisticsPanel.kt
@@ -3,7 +3,6 @@ package dartzee.screen.game
 import dartzee.core.util.maxOrZero
 import dartzee.game.state.DefaultPlayerState
 import dartzee.helper.*
-import dartzee.screen.game.scorer.DartsScorer
 import dartzee.shouldHaveColours
 import dartzee.utils.DartsColour
 import io.kotlintest.shouldBe
@@ -19,10 +18,10 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
         val clive = insertPlayer(name = "Clive")
         val alice = insertPlayer(name = "Alice")
 
-        val cliveState1 = makeDefaultPlayerState<DartsScorer>(clive, dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
-        val aliceState1 = makeDefaultPlayerState<DartsScorer>(alice, dartsThrown = listOf(makeDart()))
-        val aliceState2 = makeDefaultPlayerState<DartsScorer>(alice, dartsThrown = listOf(makeDart(), makeDart()))
-        val cliveState2 = makeDefaultPlayerState<DartsScorer>(clive, dartsThrown = listOf(makeDart(), makeDart(), makeDart(), makeDart(), makeDart()))
+        val cliveState1 = makeDefaultPlayerState(clive, dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
+        val aliceState1 = makeDefaultPlayerState(alice, dartsThrown = listOf(makeDart()))
+        val aliceState2 = makeDefaultPlayerState(alice, dartsThrown = listOf(makeDart(), makeDart()))
+        val cliveState2 = makeDefaultPlayerState(clive, dartsThrown = listOf(makeDart(), makeDart(), makeDart(), makeDart(), makeDart()))
 
         val panel = FakeGameStatisticsPanel()
         panel.showStats(listOf(cliveState1, aliceState1, aliceState2, cliveState2))
@@ -40,12 +39,12 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
     fun `Should clear down previous stats`()
     {
         val clive = insertPlayer(name = "Clive")
-        val cliveState1 = makeDefaultPlayerState<DartsScorer>(clive, dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
+        val cliveState1 = makeDefaultPlayerState(clive, dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
 
         val panel = FakeGameStatisticsPanel()
         panel.showStats(listOf(cliveState1))
 
-        val cliveState2 = makeDefaultPlayerState<DartsScorer>(clive, dartsThrown = listOf(makeDart()))
+        val cliveState2 = makeDefaultPlayerState(clive, dartsThrown = listOf(makeDart()))
         panel.showStats(listOf(cliveState2))
 
         panel.getValueForRow("Darts Thrown", 1) shouldBe 1
@@ -58,8 +57,8 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
         val alice = insertPlayer(name = "Alice")
         val bob = insertPlayer(name = "Bob")
 
-        val aliceState = makeDefaultPlayerState<DartsScorer>(alice, dartsThrown = listOf(makeDart()))
-        val bobState = makeDefaultPlayerState<DartsScorer>(bob, dartsThrown = listOf())
+        val aliceState = makeDefaultPlayerState(alice, dartsThrown = listOf(makeDart()))
+        val bobState = makeDefaultPlayerState(bob, dartsThrown = listOf())
 
         val panel = FakeGameStatisticsPanel()
         panel.showStats(listOf(aliceState, bobState))
@@ -73,12 +72,12 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
         val alice = insertPlayer(name = "Alice")
         val bob = insertPlayer(name = "Bob")
 
-        val aliceState1 = makeDefaultPlayerState<DartsScorer>(alice, insertParticipant(playerId = alice.rowId, finalScore = 50))
-        val aliceState2 = makeDefaultPlayerState<DartsScorer>(alice, insertParticipant(playerId = alice.rowId, finalScore = 35))
+        val aliceState1 = makeDefaultPlayerState(alice, insertParticipant(playerId = alice.rowId, finalScore = 50))
+        val aliceState2 = makeDefaultPlayerState(alice, insertParticipant(playerId = alice.rowId, finalScore = 35))
 
-        val bobState1 = makeDefaultPlayerState<DartsScorer>(bob, insertParticipant(playerId = bob.rowId, finalScore = 28))
-        val bobState2 = makeDefaultPlayerState<DartsScorer>(bob, insertParticipant(playerId = bob.rowId, finalScore = 70))
-        val bobState3 = makeDefaultPlayerState<DartsScorer>(bob, insertParticipant(playerId = bob.rowId, finalScore = -1))
+        val bobState1 = makeDefaultPlayerState(bob, insertParticipant(playerId = bob.rowId, finalScore = 28))
+        val bobState2 = makeDefaultPlayerState(bob, insertParticipant(playerId = bob.rowId, finalScore = 70))
+        val bobState3 = makeDefaultPlayerState(bob, insertParticipant(playerId = bob.rowId, finalScore = -1))
 
         val panel = FakeGameStatisticsPanel()
         panel.showStats(listOf(aliceState1, bobState1, bobState2, aliceState2, bobState3))
@@ -93,11 +92,11 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
         val alice = insertPlayer(name = "Alice")
         val bob = insertPlayer(name = "Bob")
 
-        val aliceState1 = makeDefaultPlayerState<DartsScorer>(alice, insertParticipant(playerId = alice.rowId, finalScore = 50))
-        val aliceState2 = makeDefaultPlayerState<DartsScorer>(alice, insertParticipant(playerId = alice.rowId, finalScore = 35))
+        val aliceState1 = makeDefaultPlayerState(alice, insertParticipant(playerId = alice.rowId, finalScore = 50))
+        val aliceState2 = makeDefaultPlayerState(alice, insertParticipant(playerId = alice.rowId, finalScore = 35))
 
-        val bobState1 = makeDefaultPlayerState<DartsScorer>(bob, insertParticipant(playerId = bob.rowId, finalScore = 28))
-        val bobState2 = makeDefaultPlayerState<DartsScorer>(bob, insertParticipant(playerId = bob.rowId, finalScore = 70))
+        val bobState1 = makeDefaultPlayerState(bob, insertParticipant(playerId = bob.rowId, finalScore = 28))
+        val bobState2 = makeDefaultPlayerState(bob, insertParticipant(playerId = bob.rowId, finalScore = 70))
 
         val panel = FakeGameStatisticsPanel()
         panel.showStats(listOf(aliceState1, bobState1, bobState2, aliceState2))
@@ -109,7 +108,7 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
     @Test
     fun `Should replace NULL values with NA`()
     {
-        val state = makeDefaultPlayerState<DartsScorer>()
+        val state = makeDefaultPlayerState()
 
         val panel = FakeGameStatisticsPanel()
         panel.showStats(listOf(state))
@@ -123,10 +122,10 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
     @Test
     fun `Should colour highest wins rows correctly`()
     {
-        val state1 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Alice"), dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
-        val state2 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Bob"), dartsThrown = listOf(makeDart()))
-        val state3 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Clive"), dartsThrown = listOf(makeDart(), makeDart()))
-        val state4 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Derek"), dartsThrown = listOf(makeDart(), makeDart(), makeDart(), makeDart()))
+        val state1 = makeDefaultPlayerState(insertPlayer(name = "Alice"), dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
+        val state2 = makeDefaultPlayerState(insertPlayer(name = "Bob"), dartsThrown = listOf(makeDart()))
+        val state3 = makeDefaultPlayerState(insertPlayer(name = "Clive"), dartsThrown = listOf(makeDart(), makeDart()))
+        val state4 = makeDefaultPlayerState(insertPlayer(name = "Derek"), dartsThrown = listOf(makeDart(), makeDart(), makeDart(), makeDart()))
 
         val panel = FakeGameStatisticsPanel(highestWins = listOf("Darts Thrown"))
         panel.showStats(listOf(state1, state2, state3, state4))
@@ -140,10 +139,10 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
     @Test
     fun `Should colour lowest wins rows correctly`()
     {
-        val state1 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Alice"), dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
-        val state2 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Bob"), dartsThrown = listOf(makeDart()))
-        val state3 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Clive"), dartsThrown = listOf(makeDart(), makeDart()))
-        val state4 = makeDefaultPlayerState<DartsScorer>(insertPlayer(name = "Derek"), dartsThrown = listOf(makeDart(), makeDart(), makeDart(), makeDart()))
+        val state1 = makeDefaultPlayerState(insertPlayer(name = "Alice"), dartsThrown = listOf(makeDart(), makeDart(), makeDart()))
+        val state2 = makeDefaultPlayerState(insertPlayer(name = "Bob"), dartsThrown = listOf(makeDart()))
+        val state3 = makeDefaultPlayerState(insertPlayer(name = "Clive"), dartsThrown = listOf(makeDart(), makeDart()))
+        val state4 = makeDefaultPlayerState(insertPlayer(name = "Derek"), dartsThrown = listOf(makeDart(), makeDart(), makeDart(), makeDart()))
 
         val panel = FakeGameStatisticsPanel(lowestWins = listOf("Darts Thrown"))
         panel.showStats(listOf(state1, state2, state3, state4))
@@ -156,7 +155,7 @@ class TestAbstractGameStatisticsPanel: AbstractTest()
 }
 
 private class FakeGameStatisticsPanel(private val highestWins: List<String> = emptyList(),
-                                      private val lowestWins: List<String> = emptyList()): AbstractGameStatisticsPanel<DefaultPlayerState<*>>()
+                                      private val lowestWins: List<String> = emptyList()): AbstractGameStatisticsPanel<DefaultPlayerState>()
 {
     override fun getRankedRowsHighestWins() = highestWins
     override fun getRankedRowsLowestWins() = lowestWins

--- a/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestDartsMatchScreen.kt
@@ -10,7 +10,6 @@ import dartzee.db.PlayerImageEntity
 import dartzee.game.state.DefaultPlayerState
 import dartzee.helper.*
 import dartzee.screen.ScreenCache
-import dartzee.screen.game.scorer.DartsScorerX01
 import dartzee.screen.game.x01.GamePanelX01
 import dartzee.screen.game.x01.MatchStatisticsPanelX01
 import io.kotlintest.matchers.collections.shouldContainExactly
@@ -111,7 +110,7 @@ class TestDartsMatchScreen: AbstractTest()
     @Test
     fun `Should pass certain fns through to the match summary panel`()
     {
-        val matchSummaryPanel = mockk<MatchSummaryPanel<DefaultPlayerState<DartsScorerX01>>>(relaxed = true)
+        val matchSummaryPanel = mockk<MatchSummaryPanel<DefaultPlayerState>>(relaxed = true)
         val scrn = setUpMatchScreen(matchSummaryPanel = matchSummaryPanel)
 
         scrn.updateTotalScores()
@@ -128,7 +127,7 @@ class TestDartsMatchScreen: AbstractTest()
         val matchEntity = mockk<DartsMatchEntity>(relaxed = true)
         every { matchEntity.isComplete() } returns true
 
-        val matchSummaryPanel = mockk<MatchSummaryPanel<DefaultPlayerState<DartsScorerX01>>>(relaxed = true)
+        val matchSummaryPanel = mockk<MatchSummaryPanel<DefaultPlayerState>>(relaxed = true)
         val scrn = setUpMatchScreen(match = matchEntity, matchSummaryPanel = matchSummaryPanel)
         scrn.startNextGameIfNecessary()
 
@@ -161,7 +160,7 @@ class TestDartsMatchScreen: AbstractTest()
     }
 
     private fun setUpMatchScreen(match: DartsMatchEntity = insertDartsMatch(gameParams = "501"),
-                                 matchSummaryPanel: MatchSummaryPanel<DefaultPlayerState<DartsScorerX01>> = MatchSummaryPanel(match, MatchStatisticsPanelX01(match.gameParams))): FakeMatchScreen
+                                 matchSummaryPanel: MatchSummaryPanel<DefaultPlayerState> = MatchSummaryPanel(match, MatchStatisticsPanelX01(match.gameParams))): FakeMatchScreen
     {
         PlayerImageEntity.createPresets()
         return FakeMatchScreen(match, listOf(insertPlayer(), insertPlayer()), matchSummaryPanel)
@@ -170,8 +169,8 @@ class TestDartsMatchScreen: AbstractTest()
 
 private class FakeMatchScreen(match: DartsMatchEntity,
                               players: List<PlayerEntity>,
-                              matchSummaryPanel: MatchSummaryPanel<DefaultPlayerState<DartsScorerX01>>):
-        DartsMatchScreen<DefaultPlayerState<DartsScorerX01>>(matchSummaryPanel, match, players)
+                              matchSummaryPanel: MatchSummaryPanel<DefaultPlayerState>):
+        DartsMatchScreen<DefaultPlayerState>(matchSummaryPanel, match, players)
 {
     override fun factoryGamePanel(parent: AbstractDartsGameScreen, game: GameEntity): GamePanelX01
     {

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelGolf.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelGolf.kt
@@ -162,7 +162,7 @@ class TestGamePanelGolf: AbstractTest()
             val pt = ParticipantEntity()
             pt.playerId = currentPlayerId
 
-            addState(0, DefaultPlayerState(pt, scorer, 0))
+            addState(0, DefaultPlayerState(pt, 0), scorer)
 
             currentRoundNumber = 1
         }

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelRoundTheClock.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelRoundTheClock.kt
@@ -133,7 +133,7 @@ class TestGamePanelRoundTheClock: AbstractTest()
             val pt = ParticipantEntity()
             pt.playerId = currentPlayerId
 
-            addState(0, DefaultPlayerState(pt, scorer, 0))
+            addState(0, DefaultPlayerState(pt, 0), scorer)
 
             currentRoundNumber = 1
         }

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelX01.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelX01.kt
@@ -142,7 +142,7 @@ class TestGamePanelX01: AbstractTest()
             val pt = ParticipantEntity()
             pt.playerId = currentPlayerId
 
-            addState(0, DefaultPlayerState(pt, scorer, 0))
+            addState(0, DefaultPlayerState(pt, 0), scorer)
 
             currentRoundNumber = 1
         }

--- a/src/test/kotlin/dartzee/screen/game/dartzee/TestGameStatisticsPanelDartzee.kt
+++ b/src/test/kotlin/dartzee/screen/game/dartzee/TestGameStatisticsPanelDartzee.kt
@@ -4,7 +4,6 @@ import dartzee.`object`.Dart
 import dartzee.dartzee.DartzeeRoundResult
 import dartzee.game.state.DartzeePlayerState
 import dartzee.helper.makeDartzeePlayerState
-import dartzee.helper.makeDartzeeScorer
 import dartzee.helper.makeRoundResultEntities
 import dartzee.screen.game.AbstractGameStatisticsPanelTest
 import dartzee.screen.game.getValueForRow
@@ -17,21 +16,16 @@ class TestGameStatisticsPanelDartzee: AbstractGameStatisticsPanelTest<DartzeePla
     {
         //Initial score of 26
         val firstRound = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1))
-        val scorer = makeDartzeeScorer(firstRound)
 
         //Score of 83
         val secondRound = listOf(Dart(19, 3), Dart(17, 1), Dart(3, 1))
-        secondRound.forEach { scorer.addDart(it) }
         val secondResult = DartzeeRoundResult(4, true, 57)
-        scorer.setResult(secondResult)
 
         //Score of 42
         val thirdRound = listOf(Dart(20, 3), Dart(20, 0), Dart(5, 1))
-        thirdRound.forEach { scorer.addDart(it) }
         val thirdResult = DartzeeRoundResult(1, false, -41)
-        scorer.setResult(thirdResult)
 
-        return makeDartzeePlayerState(scorer = scorer, dartsThrown = listOf(firstRound, secondRound, thirdRound), roundResults = listOf(secondResult, thirdResult))
+        return makeDartzeePlayerState(dartsThrown = listOf(firstRound, secondRound, thirdRound), roundResults = listOf(secondResult, thirdResult))
     }
 
     override fun factoryStatsPanel() = GameStatisticsPanelDartzee()

--- a/src/test/kotlin/dartzee/screen/game/golf/TestGameStatisticsPanelGolf.kt
+++ b/src/test/kotlin/dartzee/screen/game/golf/TestGameStatisticsPanelGolf.kt
@@ -8,15 +8,14 @@ import dartzee.helper.makeDefaultPlayerStateWithRounds
 import dartzee.helper.makeGolfRound
 import dartzee.screen.game.AbstractGameStatisticsPanelTest
 import dartzee.screen.game.getValueForRow
-import dartzee.screen.game.scorer.DartsScorerGolf
 import io.kotlintest.shouldBe
 import org.junit.Test
 
-class TestGameStatisticsPanelGolf: AbstractGameStatisticsPanelTest<DefaultPlayerState<DartsScorerGolf>, GameStatisticsPanelGolf>()
+class TestGameStatisticsPanelGolf: AbstractGameStatisticsPanelTest<DefaultPlayerState, GameStatisticsPanelGolf>()
 {
     override fun factoryStatsPanel() = GameStatisticsPanelGolf()
 
-    override fun makePlayerState(): DefaultPlayerState<DartsScorerGolf>
+    override fun makePlayerState(): DefaultPlayerState
     {
         val roundOne = makeGolfRound(1, listOf(makeDart(1, 1), makeDart(1, 1)))
         val roundTwo = makeGolfRound(2, listOf(makeDart(17, 1), makeDart(2, 3)))
@@ -29,7 +28,7 @@ class TestGameStatisticsPanelGolf: AbstractGameStatisticsPanelTest<DefaultPlayer
     {
         val roundOne = makeGolfRound(1, listOf(makeDart(1, 1, segmentType = SegmentType.OUTER_SINGLE)))
 
-        val state = makeDefaultPlayerState<DartsScorerGolf>(dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(dartsThrown = roundOne)
 
         //4
         val statsPanel = factoryStatsPanel()
@@ -68,7 +67,7 @@ class TestGameStatisticsPanelGolf: AbstractGameStatisticsPanelTest<DefaultPlayer
     {
         val roundOne = makeGolfRound(1, listOf(makeDart(1, 1, segmentType = SegmentType.OUTER_SINGLE)))
 
-        val state = makeDefaultPlayerState<DartsScorerGolf>(dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(dartsThrown = roundOne)
 
         // [Hit]
         val statsPanel = factoryStatsPanel()
@@ -93,7 +92,7 @@ class TestGameStatisticsPanelGolf: AbstractGameStatisticsPanelTest<DefaultPlayer
     {
         // 3-5-4
         val roundOne = makeGolfRound(1, listOf(makeDart(1, 1, segmentType = SegmentType.INNER_SINGLE), makeDart(20, 1), makeDart(1, 1)))
-        val state = makeDefaultPlayerState<DartsScorerGolf>(dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(dartsThrown = roundOne)
 
         val statsPanel = factoryStatsPanel()
         statsPanel.showStats(listOf(state))
@@ -120,7 +119,7 @@ class TestGameStatisticsPanelGolf: AbstractGameStatisticsPanelTest<DefaultPlayer
     {
         //4-3-2. You've gambled twice, and gained 1 each time. 2 points improved.
         val roundOne = makeGolfRound(1, listOf(makeDart(1, 1), makeDart(1, 1, SegmentType.INNER_SINGLE), makeDart(1, 3)))
-        val state = makeDefaultPlayerState<DartsScorerGolf>(dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(dartsThrown = roundOne)
         val statsPanel = factoryStatsPanel()
         statsPanel.showStats(listOf(state))
         statsPanel.getValueForRow("Points Improved") shouldBe 2
@@ -161,7 +160,7 @@ class TestGameStatisticsPanelGolf: AbstractGameStatisticsPanelTest<DefaultPlayer
     {
         val roundOne = makeGolfRound(1, listOf(makeDart(1, 1, segmentType = SegmentType.OUTER_SINGLE)))
 
-        val state = makeDefaultPlayerState<DartsScorerGolf>(dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(dartsThrown = roundOne)
 
         //4
         val statsPanel = factoryStatsPanel()

--- a/src/test/kotlin/dartzee/screen/game/rtc/TestGameStatisticsPanelRoundTheClock.kt
+++ b/src/test/kotlin/dartzee/screen/game/rtc/TestGameStatisticsPanelRoundTheClock.kt
@@ -8,15 +8,14 @@ import dartzee.helper.makeDart
 import dartzee.helper.makeDefaultPlayerStateWithRounds
 import dartzee.screen.game.AbstractGameStatisticsPanelTest
 import dartzee.screen.game.getValueForRow
-import dartzee.screen.game.scorer.DartsScorerRoundTheClock
 import io.kotlintest.shouldBe
 import org.junit.Test
 
-class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<DefaultPlayerState<DartsScorerRoundTheClock>, GameStatisticsPanelRoundTheClock>()
+class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<DefaultPlayerState, GameStatisticsPanelRoundTheClock>()
 {
     override fun factoryStatsPanel() = GameStatisticsPanelRoundTheClock(RoundTheClockConfig(ClockType.Standard, true).toJson())
 
-    override fun makePlayerState(): DefaultPlayerState<DartsScorerRoundTheClock>
+    override fun makePlayerState(): DefaultPlayerState
     {
         val roundOne = listOf(makeDart(5, 1, startingScore = 1), makeDart(1, 1, startingScore = 1), makeDart(2, 3, startingScore = 2))
         val roundTwo = listOf(makeDart(3, 1, startingScore = 3), makeDart(4, 1, startingScore = 4), makeDart(5, 1, startingScore = 5), makeDart(6, 0, startingScore = 6))
@@ -29,7 +28,7 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
     {
         val roundOne = listOf(makeDart(5, 1, startingScore = 1), makeDart(1, 1, startingScore = 1), makeDart(3, 1, startingScore = 2))
 
-        val state = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(dartsThrown = listOf(roundOne))
+        val state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(roundOne))
         val statsPanel = factoryStatsPanel()
 
         statsPanel.showStats(listOf(state))
@@ -47,8 +46,8 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
         val roundOneOther = listOf(makeDart(1, 1, startingScore = 1), makeDart(2, 0, startingScore = 2), makeDart(17, 1, startingScore = 2))
 
         val player = insertPlayer()
-        val stateOne = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(player, dartsThrown = listOf(roundOne))
-        val stateTwo = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(player, dartsThrown = listOf(roundOneOther))
+        val stateOne = makeDefaultPlayerStateWithRounds(player, dartsThrown = listOf(roundOne))
+        val stateTwo = makeDefaultPlayerStateWithRounds(player, dartsThrown = listOf(roundOneOther))
 
         val statsPanel = factoryStatsPanel()
         statsPanel.showStats(listOf(stateOne, stateTwo))
@@ -63,7 +62,7 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
     {
         val roundOne = listOf(makeDart(5, 1, startingScore = 1), makeDart(1, 0, startingScore = 1), makeDart(20, 3, startingScore = 1))
 
-        val state = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(dartsThrown = listOf(roundOne))
+        val state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(roundOne))
         val statsPanel = factoryStatsPanel()
 
         // [-]
@@ -95,7 +94,7 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
     {
         val roundOne = listOf(makeDart(5, 1, startingScore = 1), makeDart(1, 0, startingScore = 1), makeDart(20, 3, startingScore = 1))
 
-        val state = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(dartsThrown = listOf(roundOne))
+        val state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(roundOne))
         val statsPanel = factoryStatsPanel()
 
         // [-]
@@ -123,7 +122,7 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
     {
         val roundOne = listOf(makeDart(1, 1, startingScore = 1), makeDart(1, 2, startingScore = 1), makeDart(2, 1, startingScore = 2))
 
-        val state = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(dartsThrown = listOf(roundOne))
+        val state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(roundOne))
         val statsPanel = GameStatisticsPanelRoundTheClock(RoundTheClockConfig(ClockType.Doubles, true).toJson())
 
         // [2, -]
@@ -141,7 +140,7 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
     {
         val roundOne = listOf(makeDart(5, 1, startingScore = 1), makeDart(1, 1, startingScore = 1), makeDart(17, 3, startingScore = 2))
 
-        val state = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(dartsThrown = listOf(roundOne))
+        val state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(roundOne))
         val statsPanel = factoryStatsPanel()
 
         // [-]
@@ -169,7 +168,7 @@ class TestGameStatisticsPanelRoundTheClock: AbstractGameStatisticsPanelTest<Defa
         val hitRound = listOf(makeDart(5, 1, startingScore = 1), makeDart(1, 0, startingScore = 1), makeDart(1, 1, startingScore = 1))
 
         //3
-        var state = makeDefaultPlayerStateWithRounds<DartsScorerRoundTheClock>(dartsThrown = listOf(hitRound))
+        var state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(hitRound))
         val statsPanel = factoryStatsPanel()
         statsPanel.showStats(listOf(state))
         statsPanel.shouldHaveBreakdownState(mapOf("2 - 3" to 1))

--- a/src/test/kotlin/dartzee/screen/game/x01/TestGameStatisticsPanelX01.kt
+++ b/src/test/kotlin/dartzee/screen/game/x01/TestGameStatisticsPanelX01.kt
@@ -9,14 +9,13 @@ import dartzee.helper.makeX01Rounds
 import dartzee.screen.game.AbstractGameStatisticsPanelTest
 import dartzee.screen.game.getRowIndex
 import dartzee.screen.game.getValueForRow
-import dartzee.screen.game.scorer.DartsScorerX01
 import io.kotlintest.shouldBe
 import org.junit.Test
 
-class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerState<DartsScorerX01>, GameStatisticsPanelX01>()
+class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerState, GameStatisticsPanelX01>()
 {
     override fun factoryStatsPanel() = GameStatisticsPanelX01("501")
-    override fun makePlayerState() = makeDefaultPlayerState<DartsScorerX01>(dartsThrown = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1)))
+    override fun makePlayerState() = makeDefaultPlayerState(dartsThrown = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1)))
 
     @Test
     fun `Should set the maximum setupThreshold to be 1 less than the starting score`()
@@ -37,8 +36,8 @@ class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerS
         //Bob - 19, 40
         val bobDarts = makeX01Rounds(501, Dart(19, 1), Dart(3, 0), Dart(19, 0), Dart(17, 2), Dart(3, 1), Dart(3, 1))
 
-        val aliceState = makeDefaultPlayerStateWithRounds<DartsScorerX01>(insertPlayer(name = "Alice"), dartsThrown = aliceDarts)
-        val bobState = makeDefaultPlayerStateWithRounds<DartsScorerX01>(insertPlayer(name = "Bob"), dartsThrown = bobDarts)
+        val aliceState = makeDefaultPlayerStateWithRounds(insertPlayer(name = "Alice"), dartsThrown = aliceDarts)
+        val bobState = makeDefaultPlayerStateWithRounds(insertPlayer(name = "Bob"), dartsThrown = bobDarts)
 
         val statsPanel = factoryStatsPanel()
         statsPanel.showStats(listOf(aliceState, bobState))
@@ -57,7 +56,7 @@ class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerS
     {
         //100, 120
         val aliceDarts = makeX01Rounds(501, Dart(20, 3), Dart(20, 1), Dart(20, 1), Dart(20, 3), Dart(20, 3), Dart(1, 0))
-        val aliceState = makeDefaultPlayerStateWithRounds<DartsScorerX01>(insertPlayer(name = "Alice"), dartsThrown = aliceDarts)
+        val aliceState = makeDefaultPlayerStateWithRounds(insertPlayer(name = "Alice"), dartsThrown = aliceDarts)
 
         val statsPanel = factoryStatsPanel()
         statsPanel.showStats(listOf(aliceState))
@@ -90,7 +89,7 @@ class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerS
         //Sort out the startingScores
         makeX01Rounds(501, roundOne, roundTwo, roundThree, roundFour, roundFive, roundSix)
 
-        val state = makeDefaultPlayerState<DartsScorerX01>(insertPlayer(name = "Alice"), dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(insertPlayer(name = "Alice"), dartsThrown = roundOne)
         val statsPanel = GameStatisticsPanelX01("501")
         statsPanel.showStats(listOf(state))
         statsPanel.shouldHaveBreakdownState(hashMapOf("20 - 39" to 1))
@@ -125,7 +124,7 @@ class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerS
         //Sort out the startingScores
         makeX01Rounds(701, roundOne, roundTwo, roundThree, roundFour)
 
-        val state = makeDefaultPlayerState<DartsScorerX01>(insertPlayer(name = "Alice"), dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(insertPlayer(name = "Alice"), dartsThrown = roundOne)
         val statsPanel = GameStatisticsPanelX01("701")
         statsPanel.showStats(listOf(state))
         statsPanel.shouldHaveBreakdownState(hashMapOf("180" to 1))
@@ -155,7 +154,7 @@ class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerS
         //Sort out the startingScores
         makeX01Rounds(501, roundOne, roundTwo, roundThree, roundFour, roundFive)
 
-        val state = makeDefaultPlayerState<DartsScorerX01>(insertPlayer(name = "Alice"), dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(insertPlayer(name = "Alice"), dartsThrown = roundOne)
         val statsPanel = GameStatisticsPanelX01("501")
         statsPanel.showStats(listOf(state))
 
@@ -227,7 +226,7 @@ class TestGameStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerS
         makeX01Rounds(57, roundOne, roundTwo, roundThree)
         makeX01Rounds(40, separateGameFinish)
 
-        val state = makeDefaultPlayerState<DartsScorerX01>(dartsThrown = roundOne)
+        val state = makeDefaultPlayerState(dartsThrown = roundOne)
         val statsPanel = factoryStatsPanel()
 
         statsPanel.showStats(listOf(state))

--- a/src/test/kotlin/dartzee/screen/game/x01/TestMatchStatisticsPanelX01.kt
+++ b/src/test/kotlin/dartzee/screen/game/x01/TestMatchStatisticsPanelX01.kt
@@ -8,14 +8,13 @@ import dartzee.helper.makeDefaultPlayerStateWithRounds
 import dartzee.helper.makeX01Rounds
 import dartzee.screen.game.AbstractGameStatisticsPanelTest
 import dartzee.screen.game.getValueForRow
-import dartzee.screen.game.scorer.DartsScorerX01
 import io.kotlintest.shouldBe
 import org.junit.Test
 
-class TestMatchStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerState<DartsScorerX01>, MatchStatisticsPanelX01>()
+class TestMatchStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayerState, MatchStatisticsPanelX01>()
 {
     override fun factoryStatsPanel() = MatchStatisticsPanelX01("501")
-    override fun makePlayerState() = makeDefaultPlayerState<DartsScorerX01>(dartsThrown = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1)))
+    override fun makePlayerState() = makeDefaultPlayerState(dartsThrown = listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1)))
 
     @Test
     fun `Should get the correct value for best finish`()
@@ -24,7 +23,7 @@ class TestMatchStatisticsPanelX01: AbstractGameStatisticsPanelTest<DefaultPlayer
         makeX01Rounds(57, finishOne)
 
         val finishTwo = listOf(makeDart(19, 2, startingScore = 38))
-        val state = makeDefaultPlayerStateWithRounds<DartsScorerX01>(dartsThrown = listOf(finishOne, finishTwo))
+        val state = makeDefaultPlayerStateWithRounds(dartsThrown = listOf(finishOne, finishTwo))
 
         val statsPanel = factoryStatsPanel()
         statsPanel.showStats(listOf(state))

--- a/src/test/kotlin/e2e/SimulationE2E.kt
+++ b/src/test/kotlin/e2e/SimulationE2E.kt
@@ -3,6 +3,7 @@ package e2e
 import com.github.alexburlton.swingtest.clickChild
 import com.github.alexburlton.swingtest.getChild
 import dartzee.ai.AimDart
+import dartzee.ai.SimulationRunner
 import dartzee.bean.ScrollTableDartsGame
 import dartzee.core.bean.NumberField
 import dartzee.core.bean.ScrollTable
@@ -16,6 +17,7 @@ import dartzee.screen.stats.player.StatisticsTabTotalScore
 import dartzee.screen.stats.player.x01.StatisticsTabFinishBreakdown
 import dartzee.screen.stats.player.x01.StatisticsTabX01ThreeDartScores
 import dartzee.screen.stats.player.x01.StatisticsTabX01TopFinishes
+import dartzee.utils.InjectedThings
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.matchers.collections.shouldHaveSize
 import io.kotlintest.shouldBe
@@ -24,6 +26,13 @@ import javax.swing.JButton
 
 class SimulationE2E: AbstractTest()
 {
+    override fun beforeEachTest()
+    {
+        super.beforeEachTest()
+
+        InjectedThings.simulationRunner = SimulationRunner()
+    }
+
     @Test
     fun `Should be able to run a simulation of 500 games`()
     {

--- a/src/test/kotlin/e2e/SimulationHelpers.kt
+++ b/src/test/kotlin/e2e/SimulationHelpers.kt
@@ -7,6 +7,6 @@ import dartzee.screen.stats.player.PlayerStatisticsScreen
 
 fun awaitStatisticsScreen(): PlayerStatisticsScreen
 {
-    awaitCondition(20000) { getWindow { it.findChild<PlayerStatisticsScreen>() != null }?.isVisible == true }
+    awaitCondition { getWindow { it.findChild<PlayerStatisticsScreen>() != null }?.isVisible == true }
     return getWindow { it.findChild<PlayerStatisticsScreen>() != null }!!.getChild()
 }


### PR DESCRIPTION
Towards achieving a better separation between game state and UI components. No-op refactor to pull the scorers back out of the player state. 

Next PRs will be to gradually replace references to the scorers with direct state references instead. 