### PR TITLE
Throw SQL errors

### DIFF
--- a/src/main/kotlin/dartzee/db/AbstractEntity.kt
+++ b/src/main/kotlin/dartzee/db/AbstractEntity.kt
@@ -58,7 +58,7 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         return cols.map{ getColumnNameFromCreateSql(it) }.toMutableList()
     }
 
-    fun getColumnsExcluding(vararg columnsToExclude: String): MutableList<String>
+    private fun getColumnsExcluding(vararg columnsToExclude: String): MutableList<String>
     {
         val columns = getColumns()
         columnsToExclude.forEach { columns.remove(it) }
@@ -118,7 +118,7 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
                     KEY_SQL to whereSql)
         }
 
-        return if (entities.isEmpty()) null else entities.first()
+        return entities.firstOrNull()
     }
 
     fun retrieveEntities(whereSql: String = "", alias: String = ""): MutableList<E>
@@ -355,7 +355,7 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
     fun getColumnsForSelectStatement(alias: String = ""): String
     {
         var cols = getColumns().toList()
-        if (!alias.isEmpty())
+        if (alias.isNotEmpty())
         {
             cols = cols.map{ "$alias.$it" }
         }
@@ -437,16 +437,12 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         return swapInValue(statementStr, value)
     }
 
-    private fun swapInValue(statementStr: String, value: Any): String
-    {
-        return statementStr.replaceFirst(Pattern.quote("?").toRegex(), "" + value)
-    }
+    private fun swapInValue(statementStr: String, value: Any) = statementStr.replaceFirst(Pattern.quote("?").toRegex(), "" + value)
 
     private fun writeValue(ps: PreparedStatement, ix: Int, columnName: String, statementStr: String): String
     {
         val value = getField(columnName)
-        val type = getFieldType(columnName)
-        return when (type)
+        return when (getFieldType(columnName))
         {
             String::class.java -> writeString(ps, ix, value as String, statementStr)
             Long::class.java -> writeLong(ps, ix, value as Long, statementStr)
@@ -459,10 +455,8 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         }
     }
 
-    private fun getFieldFromResultSet(rs: ResultSet, columnName: String): Any?
-    {
-        val type = getFieldType(columnName)
-        return when(type)
+    private fun getFieldFromResultSet(rs: ResultSet, columnName: String): Any? =
+        when(getFieldType(columnName))
         {
             String::class.java -> rs.getString(columnName)
             Long::class.java -> rs.getLong(columnName)
@@ -476,15 +470,12 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
             SegmentType::class.java -> SegmentType.valueOf(rs.getString(columnName))
             else -> null
         }
-    }
 
-    private fun getValueForLogging(value: Any): String
-    {
-        return when (value.javaClass)
+    private fun getValueForLogging(value: Any) =
+        when (value.javaClass)
         {
             String::class.java, Timestamp::class.java -> "'$value'"
             Blob::class.java -> "BLOB:${(value as Blob).length()}"
             else -> "$value"
         }
-    }
 }

--- a/src/main/kotlin/dartzee/db/AbstractEntity.kt
+++ b/src/main/kotlin/dartzee/db/AbstractEntity.kt
@@ -11,6 +11,7 @@ import dartzee.logging.CODE_MERGE_ERROR
 import dartzee.logging.CODE_SQL_EXCEPTION
 import dartzee.logging.KEY_SQL
 import dartzee.logging.exceptions.ApplicationFault
+import dartzee.logging.exceptions.WrappedSqlException
 import dartzee.utils.Database
 import dartzee.utils.DurationTimer
 import dartzee.utils.InjectedThings
@@ -153,7 +154,7 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         }
         catch (sqle: SQLException)
         {
-            logger.logSqlException(query, "", sqle)
+            throw WrappedSqlException(query, "", sqle)
         }
 
         return ret
@@ -267,7 +268,7 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         }
         catch (sqle: SQLException)
         {
-            logger.logSqlException(updateQuery, genericUpdate, sqle)
+            throw WrappedSqlException(updateQuery, genericUpdate, sqle)
         }
         finally
         {
@@ -307,7 +308,7 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         }
         catch (sqle: SQLException)
         {
-            logger.logSqlException(insertQuery, genericInsert, sqle)
+            throw WrappedSqlException(insertQuery, genericInsert, sqle)
         }
         finally
         {
@@ -350,7 +351,7 @@ abstract class AbstractEntity<E : AbstractEntity<E>>(protected val database: Dat
         return createdTable
     }
 
-    fun createIndexes()
+    private fun createIndexes()
     {
         //Also create the indexes
         val indexes = mutableListOf<List<String>>()

--- a/src/main/kotlin/dartzee/logging/LoggerUncaughtExceptionHandler.kt
+++ b/src/main/kotlin/dartzee/logging/LoggerUncaughtExceptionHandler.kt
@@ -1,6 +1,7 @@
 package dartzee.logging
 
 import dartzee.logging.exceptions.ApplicationFault
+import dartzee.logging.exceptions.WrappedSqlException
 import dartzee.utils.InjectedThings.logger
 import java.lang.Thread.UncaughtExceptionHandler
 
@@ -12,6 +13,10 @@ class LoggerUncaughtExceptionHandler : UncaughtExceptionHandler
         {
             //Still stack trace, but don't show an error message or email a log
             logger.warn(CODE_UNCAUGHT_EXCEPTION, "Suppressing uncaught exception: $arg1", KEY_THREAD to arg0.toString(), KEY_EXCEPTION_MESSAGE to arg1.message)
+        }
+        else if (arg1 is WrappedSqlException)
+        {
+            logger.logSqlException(arg1.sqlStatement, arg1.genericStatement, arg1.sqlException)
         }
         else if (arg1 is ApplicationFault)
         {

--- a/src/main/kotlin/dartzee/logging/exceptions/WrappedSqlException.kt
+++ b/src/main/kotlin/dartzee/logging/exceptions/WrappedSqlException.kt
@@ -1,0 +1,5 @@
+package dartzee.logging.exceptions
+
+import java.sql.SQLException
+
+data class WrappedSqlException(val sqlStatement: String, val genericStatement: String, val sqlException: SQLException): Exception()

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -80,7 +80,7 @@ class Database(private val filePath: String = DATABASE_FILE_PATH, val dbName: St
 
     fun executeUpdates(statements: List<String>): Boolean
     {
-        statements.forEach{
+        statements.forEach {
             if (!executeUpdate(it))
             {
                 return false

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -4,13 +4,13 @@ import dartzee.`object`.DartsClient
 import dartzee.core.util.DialogUtil
 import dartzee.db.VersionEntity
 import dartzee.logging.*
+import dartzee.logging.exceptions.WrappedSqlException
 import dartzee.utils.InjectedThings.logger
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.util.*
-import javax.sql.rowset.CachedRowSet
 import javax.sql.rowset.RowSetProvider
 import kotlin.system.exitProcess
 
@@ -134,31 +134,29 @@ class Database(private val filePath: String = DATABASE_FILE_PATH, val dbName: St
     fun executeQuery(query: String): ResultSet
     {
         val timer = DurationTimer()
-        var crs: CachedRowSet? = null
-
         val conn = borrowConnection()
+
         try
         {
             conn.createStatement().use { s ->
-                s.executeQuery(query).use { rs ->
-                    crs = RowSetProvider.newFactory().createCachedRowSet()
-                    crs!!.populate(rs)
+                val resultSet: ResultSet = s.executeQuery(query).use { rs ->
+                    val crs = RowSetProvider.newFactory().createCachedRowSet()
+                    crs.populate(rs)
+                    crs
                 }
+
+                logger.logSql(query, "", timer.getDuration())
+                return resultSet
             }
         }
         catch (sqle: SQLException)
         {
-            logger.logSqlException(query, "", sqle)
+            throw WrappedSqlException(query, "", sqle)
         }
         finally
         {
             returnConnection(conn)
         }
-
-        logger.logSql(query, "", timer.getDuration())
-
-        //Return an empty one if something's gone wrong
-        return crs ?: RowSetProvider.newFactory().createCachedRowSet()
     }
 
     fun executeQueryAggregate(sb: StringBuilder): Int

--- a/src/test/kotlin/dartzee/db/TestAbstractEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestAbstractEntity.kt
@@ -18,7 +18,7 @@ import java.util.*
 
 class TestAbstractEntity: AbstractTest()
 {
-    var otherDatabase = makeInMemoryDatabase()
+    private var otherDatabase = makeInMemoryDatabase()
 
     override fun beforeEachTest()
     {
@@ -80,6 +80,18 @@ class TestAbstractEntity: AbstractTest()
         ex.genericStatement shouldBe "UPDATE TestTable SET DtCreation=?, DtLastUpdate=?, TestString=? WHERE RowId=?"
     }
 
+    @Test
+    fun `Should throw a wrapped SQL exception on retrieve`()
+    {
+        val dao = FakeEntity()
+
+        val ex = shouldThrow<WrappedSqlException> {
+            dao.retrieveEntities("butterfingers")
+        }
+
+        ex.sqlException.message shouldContain "BUTTERFINGERS"
+        ex.sqlStatement shouldBe "SELECT RowId, DtCreation, DtLastUpdate, TestString FROM TestTable WHERE butterfingers"
+    }
 
     @Test
     fun `Should retrieve all entities if passed a null date`()

--- a/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
@@ -82,30 +82,6 @@ class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
     }
 
     @Test
-    fun `Should log a SQLException if SQL fails checking whether a FIRST_TO match is complete`()
-    {
-        val match = DartsMatchEntity()
-        match.mode = MatchMode.FIRST_TO
-        match.rowId = "'"
-
-        match.isComplete() shouldBe false
-
-        verifyLog(CODE_SQL_EXCEPTION, Severity.ERROR)
-    }
-
-    @Test
-    fun `Should log a SQLException if SQL fails checking whether a POINTS match is complete`()
-    {
-        val match = DartsMatchEntity()
-        match.mode = MatchMode.POINTS
-        match.rowId = "'"
-        match.games = 2
-
-        match.isComplete() shouldBe false
-        verifyLog(CODE_SQL_EXCEPTION, Severity.ERROR)
-    }
-
-    @Test
     fun `Should correctly report whether a POINTS match is complete`()
     {
         val match = DartsMatchEntity.factoryPoints(2, "")

--- a/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
@@ -8,6 +8,7 @@ import dartzee.game.MatchMode
 import dartzee.helper.*
 import dartzee.logging.CODE_SQL_EXCEPTION
 import dartzee.logging.Severity
+import dartzee.logging.exceptions.WrappedSqlException
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.matchers.numerics.shouldBeBetween
@@ -15,6 +16,7 @@ import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.matchers.string.shouldNotBeEmpty
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
+import io.kotlintest.shouldThrow
 import org.junit.Test
 
 class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
@@ -29,9 +31,12 @@ class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
         insertDartsMatch(localId = 5)
         verifyNoLogs(CODE_SQL_EXCEPTION)
 
-        insertDartsMatch(localId = 5)
-        val log = verifyLog(CODE_SQL_EXCEPTION, Severity.ERROR)
-        log.errorObject?.message.shouldContain("duplicate key")
+        val ex = shouldThrow<WrappedSqlException> {
+            insertDartsMatch(localId = 5)
+        }
+
+        val sqle = ex.sqlException
+        sqle.message shouldContain "duplicate key"
 
         getCountFromTable("DartsMatch") shouldBe 1
     }

--- a/src/test/kotlin/dartzee/db/TestDatabaseMigrations.kt
+++ b/src/test/kotlin/dartzee/db/TestDatabaseMigrations.kt
@@ -58,10 +58,10 @@ class TestDatabaseMigrations: AbstractTest()
 
         val conversionFns = DatabaseMigrations.getConversionsMap().values.flatten()
         conversionFns.forEach {
-            it(dbToRunOn)
+            try { it(dbToRunOn) } catch (e: Exception) {}
         }
 
-        //Conversions will likely fail since we've not set them up
+        //Will probably have one logged, which is fine
         errorLogged()
 
         verifyNotCalled { mainDbMock.borrowConnection() }

--- a/src/test/kotlin/dartzee/db/TestGameEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestGameEntity.kt
@@ -5,7 +5,7 @@ import dartzee.core.util.getSqlDateNow
 import dartzee.game.GameType
 import dartzee.helper.*
 import dartzee.logging.CODE_SQL_EXCEPTION
-import dartzee.logging.Severity
+import dartzee.logging.exceptions.WrappedSqlException
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.matchers.collections.shouldHaveSize
@@ -13,6 +13,7 @@ import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.matchers.string.shouldNotBeEmpty
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
+import io.kotlintest.shouldThrow
 import org.junit.Test
 import java.sql.Timestamp
 
@@ -28,9 +29,12 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
         insertGame(localId = 5)
         verifyNoLogs(CODE_SQL_EXCEPTION)
 
-        insertGame(localId = 5)
-        val log = verifyLog(CODE_SQL_EXCEPTION, Severity.ERROR)
-        log.errorObject?.message shouldContain "duplicate key"
+        val ex = shouldThrow<WrappedSqlException> {
+            insertGame(localId = 5)
+        }
+
+        val sqle = ex.sqlException
+        sqle.message shouldContain "duplicate key"
 
         getCountFromTable("Game") shouldBe 1
     }

--- a/src/test/kotlin/dartzee/logging/TestLoggerUncaughtExceptionHandler.kt
+++ b/src/test/kotlin/dartzee/logging/TestLoggerUncaughtExceptionHandler.kt
@@ -2,9 +2,11 @@ package dartzee.logging
 
 import dartzee.helper.AbstractTest
 import dartzee.logging.exceptions.ApplicationFault
+import dartzee.logging.exceptions.WrappedSqlException
 import dartzee.shouldContainKeyValues
 import io.kotlintest.shouldBe
 import org.junit.Test
+import java.sql.SQLException
 
 class TestLoggerUncaughtExceptionHandler: AbstractTest()
 {
@@ -65,5 +67,24 @@ class TestLoggerUncaughtExceptionHandler: AbstractTest()
         log.errorObject shouldBe ex
         log.shouldContainKeyValues(KEY_THREAD to t.toString(), KEY_EXCEPTION_MESSAGE to "Argh")
         log.message shouldBe "Uncaught exception: Argh"
+    }
+
+    @Test
+    fun `Should log a WrappedSqlException correctly`()
+    {
+        val t = Thread("Foo")
+        val handler = LoggerUncaughtExceptionHandler()
+
+        val sqle = SQLException("Unable to select from table FOO", "State.ROLLBACK", 403)
+        val ex = WrappedSqlException("SELECT * FROM Foo WHERE Id = 'id'", "SELECT * FROM Foo WHERE Id = ?", sqle)
+        handler.uncaughtException(t, ex)
+
+        val log = verifyLog(CODE_SQL_EXCEPTION, Severity.ERROR)
+        log.errorObject shouldBe sqle
+        log.shouldContainKeyValues(KEY_GENERIC_SQL to "SELECT * FROM Foo WHERE Id = ?",
+                KEY_SQL to "SELECT * FROM Foo WHERE Id = 'id'",
+                KEY_SQL_STATE to "State.ROLLBACK",
+                KEY_ERROR_CODE to 403,
+                KEY_EXCEPTION_MESSAGE to "Unable to select from table FOO")
     }
 }

--- a/src/test/kotlin/dartzee/utils/TestDatabase.kt
+++ b/src/test/kotlin/dartzee/utils/TestDatabase.kt
@@ -7,10 +7,12 @@ import dartzee.logging.CODE_NEW_CONNECTION
 import dartzee.logging.CODE_SQL
 import dartzee.logging.CODE_SQL_EXCEPTION
 import dartzee.logging.Severity
+import dartzee.logging.exceptions.WrappedSqlException
 import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.matchers.string.shouldContain
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotThrowAny
+import io.kotlintest.shouldThrow
 import org.junit.Test
 
 class TestDatabase: AbstractTest()
@@ -112,11 +114,13 @@ class TestDatabase: AbstractTest()
     {
         val database = makeInMemoryDatabase()
         val query = "SELECT * FROM zzQueryTest"
-        database.executeQuery(query)
 
-        val log = verifyLog(CODE_SQL_EXCEPTION, Severity.ERROR)
-        log.message shouldBe "Caught SQLException for statement: $query"
-        log.errorObject?.message shouldContain "does not exist"
+        val ex = shouldThrow<WrappedSqlException> {
+            database.executeQuery(query)
+        }
+
+        ex.sqlStatement shouldBe query
+        ex.sqlException.message shouldContain "does not exist"
     }
 
     @Test


### PR DESCRIPTION
Just tackles the merge-specific errors around retrieval, insert and update. Means we'll be able to wrap the whole sync in a single top-level try/catch, and abort gracefully/tidy up when anything goes wrong