### PR TITLE
Bulk insert achievements

### DIFF
--- a/src/main/kotlin/dartzee/achievements/AbstractAchievementGamesWon.kt
+++ b/src/main/kotlin/dartzee/achievements/AbstractAchievementGamesWon.kt
@@ -24,8 +24,8 @@ abstract class AbstractAchievementGamesWon : AbstractMultiRowAchievement()
         sb.append(" AND pt.FinishingPosition = 1")
         appendPlayerSql(sb, players)
 
-        database.executeQuery(sb).use {
-            bulkInsertFromResultSet(it, database, achievementRef, achievementDetailFn = { rs -> rs.getInt("Score").toString() })
+        database.executeQuery(sb).use { rs ->
+            bulkInsertFromResultSet(rs, database, achievementRef, achievementDetailFn = { rs.getInt("Score").toString() })
         }
     }
 

--- a/src/main/kotlin/dartzee/achievements/AbstractAchievementGamesWon.kt
+++ b/src/main/kotlin/dartzee/achievements/AbstractAchievementGamesWon.kt
@@ -17,24 +17,14 @@ abstract class AbstractAchievementGamesWon : AbstractMultiRowAchievement()
     override fun populateForConversion(players: List<PlayerEntity>, database: Database)
     {
         val sb = StringBuilder()
-        sb.append(" SELECT pt.PlayerId, pt.GameId, pt.FinalScore, pt.DtFinished AS DtLastUpdate")
+        sb.append(" SELECT pt.PlayerId, pt.GameId, pt.FinalScore AS Score, pt.DtFinished AS DtAchieved")
         sb.append(" FROM Participant pt, Game g")
         sb.append(" WHERE pt.GameId = g.RowId")
         sb.append(" AND g.GameType = '$gameType'")
         sb.append(" AND pt.FinishingPosition = 1")
         appendPlayerSql(sb, players)
 
-        database.executeQuery(sb).use { rs ->
-            while (rs.next())
-            {
-                val playerId = rs.getString("PlayerId")
-                val gameId = rs.getString("GameId")
-                val finalScore = rs.getInt("FinalScore")
-                val dtLastUpdate = rs.getTimestamp("DtLastUpdate")
-
-                AchievementEntity.factoryAndSave(achievementRef, playerId, gameId, -1, "$finalScore", dtLastUpdate, database)
-            }
-        }
+        database.executeQuery(sb).use { bulkInsertFromResultSet(it, database, achievementRef) { rs -> rs.getInt("Score").toString() } }
     }
 
     override fun getBreakdownColumns() = listOf("Game", "Score", "Date Achieved")

--- a/src/main/kotlin/dartzee/achievements/AbstractAchievementGamesWon.kt
+++ b/src/main/kotlin/dartzee/achievements/AbstractAchievementGamesWon.kt
@@ -24,7 +24,9 @@ abstract class AbstractAchievementGamesWon : AbstractMultiRowAchievement()
         sb.append(" AND pt.FinishingPosition = 1")
         appendPlayerSql(sb, players)
 
-        database.executeQuery(sb).use { bulkInsertFromResultSet(it, database, achievementRef) { rs -> rs.getInt("Score").toString() } }
+        database.executeQuery(sb).use {
+            bulkInsertFromResultSet(it, database, achievementRef, achievementDetailFn = { rs -> rs.getInt("Score").toString() })
+        }
     }
 
     override fun getBreakdownColumns() = listOf("Game", "Score", "Date Achieved")

--- a/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
+++ b/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
@@ -87,7 +87,11 @@ fun ensureX01RoundsTableExists(players: List<PlayerEntity>, database: Database)
     database.executeUpdate(sb.toString())
 }
 
-fun bulkInsertFromResultSet(rs: ResultSet, database: Database, achievementRef: Int, achievementDetail: ((rs: ResultSet) -> String)? = null)
+fun bulkInsertFromResultSet(rs: ResultSet,
+                            database: Database,
+                            achievementRef: Int,
+                            achievementDetailFn: ((rs: ResultSet) -> String)? = null,
+                            achievementCounterFn: ((rs: ResultSet) -> Int)? = null)
 {
     val entities = mutableListOf<AchievementEntity>()
     while (rs.next())
@@ -95,9 +99,10 @@ fun bulkInsertFromResultSet(rs: ResultSet, database: Database, achievementRef: I
         val playerId = rs.getString("PlayerId")
         val gameId = rs.getString("GameId")
         val dtAchieved = rs.getTimestamp("DtAchieved")
-        val detail = achievementDetail?.invoke(rs) ?: ""
+        val detail = achievementDetailFn?.invoke(rs) ?: ""
+        val counter = achievementCounterFn?.invoke(rs) ?: -1
 
-        entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, -1, detail, dtAchieved, database))
+        entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, counter, detail, dtAchieved, database))
     }
 
     BulkInserter.insert(entities, database = database)

--- a/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
+++ b/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
@@ -90,8 +90,8 @@ fun ensureX01RoundsTableExists(players: List<PlayerEntity>, database: Database)
 fun bulkInsertFromResultSet(rs: ResultSet,
                             database: Database,
                             achievementRef: Int,
-                            achievementDetailFn: ((rs: ResultSet) -> String)? = null,
-                            achievementCounterFn: ((rs: ResultSet) -> Int)? = null)
+                            achievementDetailFn: (() -> String)? = null,
+                            achievementCounterFn: (() -> Int)? = null)
 {
     val entities = mutableListOf<AchievementEntity>()
     while (rs.next())
@@ -99,8 +99,8 @@ fun bulkInsertFromResultSet(rs: ResultSet,
         val playerId = rs.getString("PlayerId")
         val gameId = rs.getString("GameId")
         val dtAchieved = rs.getTimestamp("DtAchieved")
-        val detail = achievementDetailFn?.invoke(rs) ?: ""
-        val counter = achievementCounterFn?.invoke(rs) ?: -1
+        val detail = achievementDetailFn?.invoke() ?: ""
+        val counter = achievementCounterFn?.invoke() ?: -1
 
         entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, counter, detail, dtAchieved, database))
     }

--- a/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
+++ b/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
@@ -87,7 +87,7 @@ fun ensureX01RoundsTableExists(players: List<PlayerEntity>, database: Database)
     database.executeUpdate(sb.toString())
 }
 
-fun bulkInsertFromResultSet(rs: ResultSet, database: Database, achievementRef: Int)
+fun bulkInsertFromResultSet(rs: ResultSet, database: Database, achievementRef: Int, achievementDetail: ((rs: ResultSet) -> String)? = null)
 {
     val entities = mutableListOf<AchievementEntity>()
     while (rs.next())
@@ -95,8 +95,9 @@ fun bulkInsertFromResultSet(rs: ResultSet, database: Database, achievementRef: I
         val playerId = rs.getString("PlayerId")
         val gameId = rs.getString("GameId")
         val dtAchieved = rs.getTimestamp("DtAchieved")
+        val detail = achievementDetail?.invoke(rs) ?: ""
 
-        entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, -1, "", dtAchieved, database))
+        entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, -1, detail, dtAchieved, database))
     }
 
     BulkInserter.insert(entities, database = database)

--- a/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
+++ b/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
@@ -91,8 +91,11 @@ fun bulkInsertFromResultSet(rs: ResultSet,
                             database: Database,
                             achievementRef: Int,
                             achievementDetailFn: (() -> String)? = null,
-                            achievementCounterFn: (() -> Int)? = null)
+                            achievementCounterFn: (() -> Int)? = null,
+                            oneRowPerPlayer: Boolean = false)
 {
+    val playerIdsSeen = mutableSetOf<String>()
+
     val entities = mutableListOf<AchievementEntity>()
     while (rs.next())
     {
@@ -102,7 +105,10 @@ fun bulkInsertFromResultSet(rs: ResultSet,
         val detail = achievementDetailFn?.invoke() ?: ""
         val counter = achievementCounterFn?.invoke() ?: -1
 
-        entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, counter, detail, dtAchieved, database))
+        if (!oneRowPerPlayer || playerIdsSeen.add(playerId))
+        {
+            entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, counter, detail, dtAchieved, database))
+        }
     }
 
     BulkInserter.insert(entities, database = database)

--- a/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
+++ b/src/main/kotlin/dartzee/achievements/AchievementSqlUtil.kt
@@ -1,9 +1,12 @@
 package dartzee.achievements
 
 import dartzee.`object`.*
+import dartzee.db.AchievementEntity
+import dartzee.db.BulkInserter
 import dartzee.db.PlayerEntity
 import dartzee.game.GameType
 import dartzee.utils.Database
+import java.sql.ResultSet
 
 const val X01_ROUNDS_TABLE = "X01Rounds"
 const val LAST_ROUND_FROM_PARTICIPANT = "CEIL(CAST(pt.FinalScore AS DECIMAL)/3)"
@@ -82,4 +85,19 @@ fun ensureX01RoundsTableExists(players: List<PlayerEntity>, database: Database)
     sb.append(" AND zz.RoundNumber = drt.RoundNumber")
     sb.append(" AND zz.LastDartOrdinal = drt.Ordinal")
     database.executeUpdate(sb.toString())
+}
+
+fun bulkInsertFromResultSet(rs: ResultSet, database: Database, achievementRef: Int)
+{
+    val entities = mutableListOf<AchievementEntity>()
+    while (rs.next())
+    {
+        val playerId = rs.getString("PlayerId")
+        val gameId = rs.getString("GameId")
+        val dtAchieved = rs.getTimestamp("DtAchieved")
+
+        entities.add(AchievementEntity.factory(achievementRef, playerId, gameId, -1, "", dtAchieved, database))
+    }
+
+    BulkInserter.insert(entities, database = database)
 }

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01BestFinish.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01BestFinish.kt
@@ -2,7 +2,6 @@ package dartzee.achievements.x01
 
 import dartzee.achievements.ACHIEVEMENT_REF_X01_BEST_FINISH
 import dartzee.achievements.AbstractAchievement
-import dartzee.achievements.getTotalRoundScoreSql
 import dartzee.achievements.unlockThreeDartAchievement
 import dartzee.db.PlayerEntity
 import dartzee.game.GameType

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01Btbf.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01Btbf.kt
@@ -1,9 +1,6 @@
 package dartzee.achievements.x01
 
-import dartzee.achievements.ACHIEVEMENT_REF_X01_BTBF
-import dartzee.achievements.AbstractMultiRowAchievement
-import dartzee.achievements.LAST_ROUND_FROM_PARTICIPANT
-import dartzee.achievements.appendPlayerSql
+import dartzee.achievements.*
 import dartzee.db.AchievementEntity
 import dartzee.db.PlayerEntity
 import dartzee.game.GameType
@@ -35,7 +32,7 @@ class AchievementX01Btbf: AbstractMultiRowAchievement()
     {
         val sb = StringBuilder()
 
-        sb.append(" SELECT pt.PlayerId, pt.DtFinished, g.RowId AS GameId")
+        sb.append(" SELECT pt.PlayerId, pt.DtFinished AS DtAchieved, g.RowId AS GameId")
         sb.append(" FROM Game g, Participant pt, Dart drt")
         sb.append(" WHERE g.GameType = '${GameType.X01}'")
         sb.append(" AND pt.GameId = g.RowId")
@@ -46,15 +43,6 @@ class AchievementX01Btbf: AbstractMultiRowAchievement()
         sb.append(" AND drt.Score = 1")
         appendPlayerSql(sb, players)
 
-        database.executeQuery(sb).use { rs ->
-            while (rs.next())
-            {
-                val playerId = rs.getString("PlayerId")
-                val gameId = rs.getString("GameId")
-                val dtAchieved = rs.getTimestamp("DtFinished")
-
-                AchievementEntity.factoryAndSave(achievementRef, playerId, gameId, -1, "", dtAchieved, database)
-            }
-        }
+        database.executeQuery(sb).use { bulkInsertFromResultSet(it, database, achievementRef) }
     }
 }

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
@@ -1,8 +1,6 @@
 package dartzee.achievements.x01
 
-import dartzee.achievements.ACHIEVEMENT_REF_X01_CHECKOUT_COMPLETENESS
-import dartzee.achievements.AbstractMultiRowAchievement
-import dartzee.achievements.appendPlayerSql
+import dartzee.achievements.*
 import dartzee.core.bean.paint
 import dartzee.db.AchievementEntity
 import dartzee.game.GameType
@@ -39,21 +37,18 @@ class AchievementX01CheckoutCompleteness : AbstractMultiRowAchievement()
 
     override fun populateForConversion(players: List<PlayerEntity>, database: Database)
     {
+        ensureX01RoundsTableExists(players, database)
+
         val tempTable = database.createTempTable("PlayerCheckouts", "PlayerId VARCHAR(36), Score INT, GameId VARCHAR(36), DtAchieved TIMESTAMP")
                       ?: return
 
         var sb = StringBuilder()
 
         sb.append(" INSERT INTO $tempTable")
-        sb.append(" SELECT pt.PlayerId, d.Score, g.RowId, d.DtCreation")
-        sb.append(" FROM Dart d, Participant pt, Game g")
-        sb.append(" WHERE d.Multiplier = 2")
-        sb.append(" AND d.StartingScore = (d.Score * d.Multiplier)")
-        sb.append(" AND d.ParticipantId = pt.RowId")
-        sb.append(" AND d.PlayerId = pt.PlayerId")
-        sb.append(" AND pt.GameId = g.RowId")
-        sb.append(" AND g.GameType = '${GameType.X01}'")
-        appendPlayerSql(sb, players)
+        sb.append(" SELECT PlayerId, LastDartScore, GameId, DtRoundFinished")
+        sb.append(" FROM $X01_ROUNDS_TABLE")
+        sb.append(" WHERE LastDartMultiplier = 2")
+        sb.append(" AND RemainingScore = 0")
 
         if (!database.executeUpdate("" + sb))
             return
@@ -69,16 +64,8 @@ class AchievementX01CheckoutCompleteness : AbstractMultiRowAchievement()
         sb.append("     AND zz2.DtAchieved < zz1.DtAchieved")
         sb.append(")")
 
-        database.executeQuery(sb).use { rs ->
-            while (rs.next())
-            {
-                val playerId = rs.getString("PlayerId")
-                val score = rs.getInt("Score")
-                val gameId = rs.getString("GameId")
-                val dtAchieved = rs.getTimestamp("DtAchieved")
-
-                AchievementEntity.factoryAndSave(achievementRef, playerId, gameId, score, "", dtAchieved, database)
-            }
+        database.executeQuery(sb).use {
+            bulkInsertFromResultSet(it, database, achievementRef, achievementCounterFn = { rs -> rs.getInt("Score") })
         }
     }
 

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01CheckoutCompleteness.kt
@@ -64,8 +64,8 @@ class AchievementX01CheckoutCompleteness : AbstractMultiRowAchievement()
         sb.append("     AND zz2.DtAchieved < zz1.DtAchieved")
         sb.append(")")
 
-        database.executeQuery(sb).use {
-            bulkInsertFromResultSet(it, database, achievementRef, achievementCounterFn = { rs -> rs.getInt("Score") })
+        database.executeQuery(sb).use { rs ->
+            bulkInsertFromResultSet(rs, database, achievementRef, achievementCounterFn = { rs.getInt("Score") })
         }
     }
 

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
@@ -5,10 +5,8 @@ import dartzee.db.AchievementEntity
 import dartzee.db.PlayerEntity
 import dartzee.game.GameType
 import dartzee.utils.Database
-import dartzee.utils.InjectedThings.logger
 import dartzee.utils.ResourceCache.URL_ACHIEVEMENT_X01_HOTEL_INSPECTOR
 import java.net.URL
-import java.sql.SQLException
 
 class AchievementX01HotelInspector : AbstractMultiRowAchievement()
 {
@@ -95,18 +93,7 @@ class AchievementX01HotelInspector : AbstractMultiRowAchievement()
         sb.append("     AND zz2.DtAchieved < zz.DtAchieved")
         sb.append(" )")
 
-        val rs = database.executeQuery(sb)
-        rs.use {
-            while (rs.next())
-            {
-                val playerId = rs.getString("PlayerId")
-                val gameId = rs.getString("GameId")
-                val method = rs.getString("Method")
-                val dtAchieved = rs.getTimestamp("DtAchieved")
-
-                AchievementEntity.factoryAndSave(achievementRef, playerId, gameId, -1, method, dtAchieved, database)
-            }
-        }
+        database.executeQuery(sb).use { bulkInsertFromResultSet(it, database, achievementRef) { rs -> rs.getString("Method") } }
     }
 
     private fun getDartHigherThanSql(hAlias: String, lAlias: String): String

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
@@ -93,8 +93,8 @@ class AchievementX01HotelInspector : AbstractMultiRowAchievement()
         sb.append("     AND zz2.DtAchieved < zz.DtAchieved")
         sb.append(" )")
 
-        database.executeQuery(sb).use {
-            bulkInsertFromResultSet(it, database, achievementRef, achievementDetailFn = { rs -> rs.getString("Method") } )
+        database.executeQuery(sb).use { rs ->
+            bulkInsertFromResultSet(rs, database, achievementRef, achievementDetailFn = { rs.getString("Method") } )
         }
     }
 

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
@@ -30,37 +30,46 @@ class AchievementX01HotelInspector : AbstractMultiRowAchievement()
 
     override fun populateForConversion(players: List<PlayerEntity>, database: Database)
     {
+        ensureX01RoundsTableExists(players, database)
+        val burltonConstantRounds = database.createTempTable("BurltonConstantRounds", "PlayerId VARCHAR(36), ParticipantId VARCHAR(36), GameId VARCHAR(36), RoundNumber INT")
+
+        var sb = StringBuilder()
+        sb.append(" INSERT INTO $burltonConstantRounds")
+        sb.append(" SELECT PlayerId, ParticipantId, GameId, RoundNumber")
+        sb.append(" FROM $X01_ROUNDS_TABLE")
+        sb.append(" WHERE StartingScore - RemainingScore = 26")
+        sb.append(" AND TotalDartsThrown = 3")
+        sb.append(" AND (RemainingScore > 1 OR RemainingScore = 0 AND LastDartMultiplier = 2)")
+
+        if (!database.executeUpdate(sb)) return
+
         val tempTable = database.createTempTable("BurltonConstants", "PlayerId VARCHAR(36), ParticipantId VARCHAR(36), GameId VARCHAR(36), Ordinal INT, Score INT, Multiplier INT, RoundNumber INT, DtCreation TIMESTAMP")
         tempTable ?: return
 
-        var sb = StringBuilder()
+        sb = StringBuilder()
         sb.append(" INSERT INTO $tempTable")
-        sb.append(" SELECT pt.PlayerId, pt.RowId, pt.GameId, d.Ordinal, d.Score, d.Multiplier, d.RoundNumber, d.DtCreation")
-        sb.append(" FROM Dart d, Dart drtFirst, Dart drtSecond, Dart drtLast, Participant pt, Game g")
-        sb.append(" WHERE drtFirst.ParticipantId = pt.RowId")
-        sb.append(" AND drtFirst.PlayerId = pt.PlayerId")
-        sb.append(" AND drtSecond.ParticipantId = pt.RowId")
-        sb.append(" AND drtSecond.PlayerId = pt.PlayerId")
-        sb.append(" AND drtLast.ParticipantId = pt.RowId")
-        sb.append(" AND drtLast.PlayerId = pt.PlayerId")
-        sb.append(" AND d.RoundNumber = drtFirst.RoundNumber")
-        sb.append(" AND drtFirst.RoundNumber = drtSecond.RoundNumber")
-        sb.append(" AND drtSecond.RoundNumber = drtLast.RoundNumber")
-        sb.append(" AND d.ParticipantId = pt.RowId")
-        sb.append(" AND d.PlayerId = pt.PlayerId")
-        sb.append(" AND pt.GameId = g.RowId")
-        sb.append(" AND g.GameType = '${GameType.X01}'")
+        sb.append(" SELECT zz.PlayerId, zz.ParticipantId, zz.GameId, d.Ordinal, d.Score, d.Multiplier, d.RoundNumber, d.DtCreation")
+        sb.append(" FROM Dart d, Dart drtFirst, Dart drtSecond, Dart drtLast, $burltonConstantRounds zz")
+        sb.append(" WHERE drtFirst.ParticipantId = zz.ParticipantId")
+        sb.append(" AND drtFirst.PlayerId = zz.PlayerId")
+        sb.append(" AND drtFirst.RoundNumber = zz.RoundNumber")
+        sb.append(" AND drtSecond.ParticipantId = zz.ParticipantId")
+        sb.append(" AND drtSecond.PlayerId = zz.PlayerId")
+        sb.append(" AND drtSecond.RoundNumber = zz.RoundNumber")
+        sb.append(" AND drtLast.ParticipantId = zz.ParticipantId")
+        sb.append(" AND drtLast.PlayerId = zz.PlayerId")
+        sb.append(" AND drtLast.RoundNumber = zz.RoundNumber")
+        sb.append(" AND d.RoundNumber = zz.RoundNumber")
+        sb.append(" AND d.ParticipantId = zz.ParticipantId")
+        sb.append(" AND d.PlayerId = zz.PlayerId")
         sb.append(" AND drtFirst.Ordinal = 1")
         sb.append(" AND drtSecond.Ordinal = 2")
         sb.append(" AND drtLast.Ordinal = 3")
         sb.append(" AND drtFirst.Multiplier > 0")
         sb.append(" AND drtSecond.Multiplier > 0")
         sb.append(" AND drtLast.Multiplier > 0")
-        sb.append(" AND ${getTotalRoundScoreSql("drtFirst")} = 26")
-        sb.append(" AND ${getNotBustSql()}")
-        appendPlayerSql(sb, players)
 
-        if (!database.executeUpdate("" + sb)) return
+        if (!database.executeUpdate(sb)) return
 
         database.executeUpdate("CREATE INDEX ${tempTable}_PlayerId_ParticipantId_RoundNumber ON $tempTable(PlayerId, ParticipantId, RoundNumber)")
         val tempTableTwo = database.createTempTable("BurltonConstantsFlat", "PlayerId VARCHAR(36), GameId VARCHAR(36), DtAchieved TIMESTAMP, Method VARCHAR(100)")
@@ -79,7 +88,7 @@ class AchievementX01HotelInspector : AbstractMultiRowAchievement()
         sb.append(" AND (${getDartHigherThanSql("mediumDart", "lowestDart")})")
         sb.append(" GROUP BY highestDart.PlayerId, highestDart.GameId, highestDart.DtCreation, ${getThreeDartMethodSqlStr()}")
 
-        if (!database.executeUpdate("" + sb)) return
+        if (!database.executeUpdate(sb)) return
 
         sb = StringBuilder()
         sb.append(" SELECT PlayerId, GameId, DtAchieved, Method")

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01HotelInspector.kt
@@ -93,7 +93,9 @@ class AchievementX01HotelInspector : AbstractMultiRowAchievement()
         sb.append("     AND zz2.DtAchieved < zz.DtAchieved")
         sb.append(" )")
 
-        database.executeQuery(sb).use { bulkInsertFromResultSet(it, database, achievementRef) { rs -> rs.getString("Method") } }
+        database.executeQuery(sb).use {
+            bulkInsertFromResultSet(it, database, achievementRef, achievementDetailFn = { rs -> rs.getString("Method") } )
+        }
     }
 
     private fun getDartHigherThanSql(hAlias: String, lAlias: String): String

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01NoMercy.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01NoMercy.kt
@@ -1,9 +1,6 @@
 package dartzee.achievements.x01
 
-import dartzee.achievements.ACHIEVEMENT_REF_X01_NO_MERCY
-import dartzee.achievements.AbstractMultiRowAchievement
-import dartzee.achievements.LAST_ROUND_FROM_PARTICIPANT
-import dartzee.achievements.appendPlayerSql
+import dartzee.achievements.*
 import dartzee.db.AchievementEntity
 import dartzee.db.PlayerEntity
 import dartzee.game.GameType
@@ -29,7 +26,7 @@ class AchievementX01NoMercy: AbstractMultiRowAchievement()
     override fun populateForConversion(players: List<PlayerEntity>, database: Database)
     {
         val sb = StringBuilder()
-        sb.append(" SELECT drt.StartingScore, pt.PlayerId, pt.GameId, pt.DtFinished")
+        sb.append(" SELECT drt.StartingScore, pt.PlayerId, pt.GameId, pt.DtFinished AS DtAchieved")
         sb.append(" FROM Game g, Participant pt, Dart drt")
         sb.append(" WHERE pt.GameId = g.RowId")
         sb.append(" AND g.GameType = '${GameType.X01}'")
@@ -42,15 +39,7 @@ class AchievementX01NoMercy: AbstractMultiRowAchievement()
         appendPlayerSql(sb, players)
 
         database.executeQuery(sb).use { rs ->
-            while (rs.next())
-            {
-                val playerId = rs.getString("PlayerId")
-                val score = rs.getInt("StartingScore")
-                val gameId = rs.getString("GameId")
-                val dtAchieved = rs.getTimestamp("DtFinished")
-
-                AchievementEntity.factoryAndSave(ACHIEVEMENT_REF_X01_NO_MERCY, playerId, gameId, -1, "$score", dtAchieved, database)
-            }
+            bulkInsertFromResultSet(rs, database, achievementRef, achievementDetailFn = { rs.getInt("StartingScore").toString() })
         }
     }
 

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01Shanghai.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01Shanghai.kt
@@ -31,23 +31,16 @@ class AchievementX01Shanghai : AbstractMultiRowAchievement()
 
     override fun populateForConversion(players: List<PlayerEntity>, database: Database)
     {
+        ensureX01RoundsTableExists(players, database)
+
         val tempTable = database.createTempTable("Shanghai", "RoundNumber INT, ParticipantId VARCHAR(36), PlayerId VARCHAR(36), GameId VARCHAR(36)")
 
         var sb = StringBuilder()
         sb.append(" INSERT INTO $tempTable")
-        sb.append(" SELECT DISTINCT drtFirst.RoundNumber, pt.RowId, pt.PlayerId, pt.GameId")
-        sb.append(" FROM Dart drtFirst, Dart drtLast, Participant pt, Game g")
-        sb.append(" WHERE drtFirst.ParticipantId = pt.RowId")
-        sb.append(" AND drtFirst.PlayerId = pt.PlayerId")
-        sb.append(" AND drtLast.ParticipantId = pt.RowId")
-        sb.append(" AND drtLast.PlayerId = pt.PlayerId")
-        sb.append(" AND pt.GameId = g.RowId")
-        sb.append(" AND g.GameType = '${GameType.X01}'")
-        sb.append(" AND drtFirst.Ordinal = 1")
-        sb.append(" AND drtLast.Ordinal = 3")
-        sb.append(" AND drtLast.RoundNumber = drtFirst.RoundNumber")
-        sb.append(" AND ${getTotalRoundScoreSql("drtFirst")} = 120")
-        appendPlayerSql(sb, players)
+        sb.append(" SELECT RoundNumber, ParticipantId, PlayerId, GameId")
+        sb.append(" FROM $X01_ROUNDS_TABLE")
+        sb.append(" WHERE TotalDartsThrown = 3")
+        sb.append(" AND StartingScore - RemainingScore = 120")
 
         if (!database.executeUpdate("" + sb)) return
 

--- a/src/main/kotlin/dartzee/achievements/x01/AchievementX01Shanghai.kt
+++ b/src/main/kotlin/dartzee/achievements/x01/AchievementX01Shanghai.kt
@@ -1,9 +1,6 @@
 package dartzee.achievements.x01
 
-import dartzee.achievements.ACHIEVEMENT_REF_X01_SHANGHAI
-import dartzee.achievements.AbstractMultiRowAchievement
-import dartzee.achievements.appendPlayerSql
-import dartzee.achievements.getTotalRoundScoreSql
+import dartzee.achievements.*
 import dartzee.db.AchievementEntity
 import dartzee.db.PlayerEntity
 import dartzee.game.GameType
@@ -74,15 +71,6 @@ class AchievementX01Shanghai : AbstractMultiRowAchievement()
         sb.append(" AND drtSingle.Multiplier = 1")
         sb.append(" AND drtSingle.Score = 20")
 
-        database.executeQuery(sb).use { rs ->
-            while (rs.next())
-            {
-                val playerId = rs.getString("PlayerId")
-                val gameId = rs.getString("GameId")
-                val dtAchieved = rs.getTimestamp("DtAchieved")
-
-                AchievementEntity.factoryAndSave(achievementRef, playerId, gameId, -1, "", dtAchieved, database)
-            }
-        }
+        database.executeQuery(sb).use { bulkInsertFromResultSet(it, database, achievementRef) }
     }
 }

--- a/src/main/kotlin/dartzee/db/AchievementEntity.kt
+++ b/src/main/kotlin/dartzee/db/AchievementEntity.kt
@@ -154,7 +154,8 @@ class AchievementEntity(database: Database = mainDatabase) : AbstractEntity<Achi
                     playerId: String,
                     gameId: String,
                     counter: Int,
-                    achievementDetail: String = "",
+                    achievementDetail: String,
+                    dtAchieved: Timestamp,
                     database: Database = mainDatabase): AchievementEntity
         {
             val ae = AchievementEntity(database)
@@ -164,6 +165,7 @@ class AchievementEntity(database: Database = mainDatabase) : AbstractEntity<Achi
             ae.gameIdEarned = gameId
             ae.achievementCounter = counter
             ae.achievementDetail = achievementDetail
+            ae.dtAchieved = dtAchieved
             return ae
         }
 
@@ -175,16 +177,8 @@ class AchievementEntity(database: Database = mainDatabase) : AbstractEntity<Achi
                            dtAchieved: Timestamp = getSqlDateNow(),
                            database: Database = mainDatabase): AchievementEntity
         {
-            val ae = AchievementEntity(database)
-            ae.assignRowId()
-            ae.achievementRef = achievementRef
-            ae.playerId = playerId
-            ae.gameIdEarned = gameId
-            ae.achievementCounter = counter
-            ae.achievementDetail = achievementDetail
-            ae.dtAchieved = dtAchieved
+            val ae = factory(achievementRef, playerId, gameId, counter, achievementDetail, dtAchieved, database)
             ae.saveToDatabase()
-
             return ae
         }
     }

--- a/src/test/kotlin/dartzee/achievements/x01/TestAchievementX01HotelInspector.kt
+++ b/src/test/kotlin/dartzee/achievements/x01/TestAchievementX01HotelInspector.kt
@@ -5,6 +5,7 @@ import dartzee.achievements.ACHIEVEMENT_REF_X01_HOTEL_INSPECTOR
 import dartzee.achievements.AbstractMultiRowAchievementTest
 import dartzee.db.AchievementEntity
 import dartzee.db.GameEntity
+import dartzee.db.ParticipantEntity
 import dartzee.db.PlayerEntity
 import dartzee.helper.getCountFromTable
 import dartzee.helper.insertDart
@@ -61,6 +62,24 @@ class TestAchievementX01HotelInspector: AbstractMultiRowAchievementTest<Achievem
         factoryAchievement().populateForConversion(emptyList())
 
         getCountFromTable("Achievement") shouldBe 0
+    }
+
+    @Test
+    fun `Should ignore rounds that do not add up to 26, in a game where another round does add up to 26`()
+    {
+        val p = insertPlayer()
+        val g = insertRelevantGame()
+        val pt = insertParticipant(playerId = p.rowId, gameId = g.rowId)
+
+        insertDartsForPlayer(g, p, listOf(Dart(20, 1), Dart(5, 1), Dart(2, 1)),
+            participant = pt, roundNumber = 1)
+
+        insertDartsForPlayer(g, p, listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1)),
+            participant = pt, roundNumber = 2)
+
+        factoryAchievement().populateForConversion(emptyList())
+
+        getCountFromTable("Achievement") shouldBe 1
     }
 
     @Test
@@ -132,13 +151,19 @@ class TestAchievementX01HotelInspector: AbstractMultiRowAchievementTest<Achievem
         insertDartsForPlayer(g, p, listOf(Dart(20, 1), Dart(5, 1), Dart(1, 1)), database = database)
     }
 
-    private fun insertDartsForPlayer(g: GameEntity, p: PlayerEntity, darts: List<Dart>, startingScore: Int = 501, database: Database = mainDatabase)
+    private fun insertDartsForPlayer(g: GameEntity,
+                                     p: PlayerEntity,
+                                     darts: List<Dart>,
+                                     startingScore: Int = 501,
+                                     database: Database = mainDatabase,
+                                     participant: ParticipantEntity? = null,
+                                     roundNumber: Int = 1)
     {
-        val pt = insertParticipant(playerId = p.rowId, gameId = g.rowId, database = database)
+        val pt = participant ?: insertParticipant(playerId = p.rowId, gameId = g.rowId, database = database)
 
         var currentScore = startingScore
         darts.forEachIndexed { ix, drt ->
-            insertDart(pt, score = drt.score, multiplier = drt.multiplier, ordinal = ix+1, startingScore = currentScore, database = database)
+            insertDart(pt, score = drt.score, multiplier = drt.multiplier, ordinal = ix+1, startingScore = currentScore, roundNumber = roundNumber, database = database)
             currentScore -= drt.getTotal()
         }
 


### PR DESCRIPTION
More achievement conversion improvements:

 - Bulk insert utility to reduce boiler plate and speed up conversions
 - Move more X01 achievements towards using the X01Rounds temp table. This slows them down when run individually, but makes for a better overall time when running for all achievements.

Timings as of this PR for all players + all achievements:

```
[conversion.timings] Done in 24486. Breakdown: {X01 Winner=1362, Golf Winner=213, Clock Winner=119, Leg-up=311, Career Round=300, Stop the Clock!=241, Finisher=12046, Three Darter=1639, Completionist=323, Bognor=551, Gambler=1191, Didn't he do well!?=228, Shanghai=157, Hotel Inspector=1022, Such Bad Luck=2672, BTBF=1031, Like Clockwork=383, No Mercy=271, Course Master=390, Dartzee Winner=36}
```