### PR TITLE
Go off changed achievements, not darts

### DIFF
--- a/src/main/kotlin/dartzee/db/DatabaseMerger.kt
+++ b/src/main/kotlin/dartzee/db/DatabaseMerger.kt
@@ -1,6 +1,6 @@
 package dartzee.db
 
-import dartzee.achievements.getAllAchievements
+import dartzee.achievements.getAchievementForRef
 import dartzee.achievements.runConversionsWithProgressBar
 import dartzee.core.util.DialogUtil
 import dartzee.logging.CODE_MERGE_ERROR
@@ -51,10 +51,12 @@ class DatabaseMerger(private val localDatabase: Database,
         val lastLocalSync = SyncAuditEntity.getLastSyncDate(localDatabase, remoteName)
         getSyncEntities().forEach { dao -> syncRowsFromTable(dao, lastLocalSync) }
 
-        val playersAffected = DartEntity().retrieveModifiedSince(lastLocalSync).map { it.playerId }.distinct()
-        if (playersAffected.isNotEmpty())
+        val achievementsChanged = AchievementEntity().retrieveModifiedSince(lastLocalSync)
+        if (achievementsChanged.isNotEmpty())
         {
-            val t = runConversionsWithProgressBar(getAllAchievements(), playersAffected, remoteDatabase)
+            val players = achievementsChanged.map { it.playerId }.distinct()
+            val achievements = achievementsChanged.mapNotNull { getAchievementForRef(it.achievementRef) }
+            val t = runConversionsWithProgressBar(achievements, players, remoteDatabase)
             t.join()
         }
 

--- a/src/main/kotlin/dartzee/db/DatabaseMerger.kt
+++ b/src/main/kotlin/dartzee/db/DatabaseMerger.kt
@@ -55,7 +55,8 @@ class DatabaseMerger(private val localDatabase: Database,
         if (achievementsChanged.isNotEmpty())
         {
             val players = achievementsChanged.map { it.playerId }.distinct()
-            val achievements = achievementsChanged.mapNotNull { getAchievementForRef(it.achievementRef) }
+            val achievementRefs = achievementsChanged.map { it.achievementRef }.distinct()
+            val achievements = achievementRefs.mapNotNull(::getAchievementForRef)
             val t = runConversionsWithProgressBar(achievements, players, remoteDatabase)
             t.join()
         }


### PR DESCRIPTION
Just when I thought I was done with these...

Slight tweak to the logic determining when we run an achievement conversion for the merge. By going off `Achievement` rather than `Dart`, it will mean:

 - Better efficiency - we'll run for a subset of achievementRefs that have actually changed, and won't include players who may have thrown darts that didn't affect their achievements in any way.
 - Better syncing - if a new achievement is added, then Dartzee automatically populates it on boot after an update. These rows will trigger the merge to do the same thing. In addition, any achievement conversion run locally between syncs will be re-run as part of the sync.