### PR TITLE
Bug fix: RTC scorecard

### DIFF
--- a/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorer.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/AbstractDartsScorer.kt
@@ -111,6 +111,11 @@ abstract class AbstractDartsScorer<PlayerState: AbstractPlayerState<PlayerState>
         panelCenter.repaint()
     }
 
+    open fun allAchievementsClosed()
+    {
+        panelCenter.add(tableScores)
+    }
+
     inner class AchievementOverlay(achievement: AbstractAchievement) : JPanel(), ActionListener, MouseListener
     {
         private val btnClose = JButton("X")
@@ -187,7 +192,7 @@ abstract class AbstractDartsScorer<PlayerState: AbstractPlayerState<PlayerState>
             }
             else
             {
-                panelCenter.add(tableScores)
+                allAchievementsClosed()
             }
 
             panelCenter.revalidate()

--- a/src/main/kotlin/dartzee/screen/game/scorer/DartsScorerRoundTheClock.kt
+++ b/src/main/kotlin/dartzee/screen/game/scorer/DartsScorerRoundTheClock.kt
@@ -27,6 +27,16 @@ class DartsScorerRoundTheClock(parent: GamePanelPausable<*, *>, private val cloc
         }
     }
 
+    override fun allAchievementsClosed()
+    {
+        super.allAchievementsClosed()
+
+        if (!clockConfig.inOrder)
+        {
+            panelCenter.add(tableRemaining, BorderLayout.NORTH)
+        }
+    }
+
     override fun stateChangedImpl(state: ClockPlayerState)
     {
         tableRemaining.stateChanged(state, getPaused())

--- a/src/test/kotlin/dartzee/screen/game/scorer/ScorerTestHelpers.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/ScorerTestHelpers.kt
@@ -1,0 +1,11 @@
+package dartzee.screen.game.scorer
+
+import com.github.alexburlton.swingtest.clickChild
+import com.github.alexburlton.swingtest.findChild
+import com.github.alexburlton.swingtest.getChild
+import dartzee.core.bean.SwingLabel
+import javax.swing.JButton
+
+fun AbstractDartsScorer<*>.getAchievementOverlay() = findChild<AbstractDartsScorer<*>.AchievementOverlay>()
+fun AbstractDartsScorer<*>.AchievementOverlay.getAchievementName() = getChild<SwingLabel> { it.testId == "achievementName" }.text
+fun AbstractDartsScorer<*>.AchievementOverlay.close() = clickChild<JButton>("X")

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorer.kt
@@ -1,13 +1,9 @@
 package dartzee.screen.game.scorer
 
-import com.github.alexburlton.swingtest.clickChild
-import com.github.alexburlton.swingtest.findChild
-import com.github.alexburlton.swingtest.getChild
 import dartzee.`object`.Dart
 import dartzee.achievements.x01.AchievementX01BestFinish
 import dartzee.achievements.x01.AchievementX01BestGame
 import dartzee.achievements.x01.AchievementX01GamesWon
-import dartzee.core.bean.SwingLabel
 import dartzee.game.state.TestPlayerState
 import dartzee.getRows
 import dartzee.helper.AbstractTest
@@ -19,7 +15,6 @@ import io.kotlintest.matchers.collections.shouldContainExactly
 import io.kotlintest.shouldBe
 import org.junit.Test
 import java.awt.Color
-import javax.swing.JButton
 
 class TestAbstractDartsScorer: AbstractTest()
 {
@@ -112,10 +107,6 @@ class TestAbstractDartsScorer: AbstractTest()
 
         scorer.getAchievementOverlay() shouldBe null
     }
-
-    private fun AbstractDartsScorer<*>.getAchievementOverlay() = findChild<AbstractDartsScorer<*>.AchievementOverlay>()
-    private fun AbstractDartsScorer<*>.AchievementOverlay.getAchievementName() = getChild<SwingLabel> { it.testId == "achievementName" }.text
-    private fun AbstractDartsScorer<*>.AchievementOverlay.close() = clickChild<JButton>("X")
 
     private class TestDartsScorer: AbstractDartsScorer<TestPlayerState>()
     {

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestDartsScorerRoundTheClock.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestDartsScorerRoundTheClock.kt
@@ -3,6 +3,7 @@ package dartzee.screen.game.scorer
 import com.github.alexburlton.swingtest.findChild
 import dartzee.`object`.Dart
 import dartzee.`object`.DartNotThrown
+import dartzee.achievements.rtc.AchievementClockBestGame
 import dartzee.firstRow
 import dartzee.game.ClockType
 import dartzee.game.RoundTheClockConfig
@@ -108,6 +109,17 @@ class TestDartsScorerRoundTheClock: AbstractTest()
 
         val scorerAnyOrder = factoryScorer(inOrder = false)
         scorerAnyOrder.findChild<RoundTheClockScorecard>().shouldNotBeNull()
+    }
+
+    @Test
+    fun `Should add back the scorecard when achievement popup is dismissed`()
+    {
+        val scorer = factoryScorer(inOrder = false)
+        scorer.achievementUnlocked(AchievementClockBestGame())
+
+        scorer.findChild<RoundTheClockScorecard>().shouldBeNull()
+        scorer.getAchievementOverlay()!!.close()
+        scorer.findChild<RoundTheClockScorecard>().shouldNotBeNull()
     }
 
     private fun factoryScorer(clockType: ClockType = ClockType.Standard, inOrder: Boolean = true): DartsScorerRoundTheClock


### PR DESCRIPTION
Fix for: https://trello.com/c/Igaxt37Q/159-disappearing-scorecard-in-rtc-out-of-order-mode-after-achievement-popup