### PR TITLE
Don't restart app when database swapped in

### DIFF
--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -13,7 +13,6 @@ import org.apache.derby.jdbc.EmbeddedDriver
 import java.io.File
 import java.sql.DriverManager
 import javax.swing.JOptionPane
-import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
 
 /**
@@ -125,9 +124,8 @@ object DartsDatabaseUtil
         if (swapInDatabase(directoryFrom))
         {
             mainDatabase.shutDown()
-            initialiseDatabase(mainDatabase)
-
-            SwingUtilities.invokeLater { DialogUtil.showInfo("Database successfully restored!") }
+            mainDatabase.initialiseConnectionPool(5)
+            DialogUtil.showInfo("Database successfully restored!")
         }
     }
 
@@ -175,7 +173,7 @@ object DartsDatabaseUtil
         val testSuccess = otherDatabase.testConnection()
         if (!testSuccess)
         {
-            DialogUtil.showError("Testing conection failed for the selected database. Cannot restore from this location.")
+            DialogUtil.showError("Testing connection failed for the selected database. Cannot restore from this location.")
             return null
         }
 

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -280,25 +280,30 @@ class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = D
         return true
     }
 
-    fun shutdownDerby(): Boolean
+    fun shutDown(): Boolean
     {
         try
         {
-            createDatabaseConnection(dbName = "jdbc:derby:;shutdown=true")
+            createDatabaseConnection(dbName = "jdbc:derby:Databases/Darts;shutdown=true")
         }
         catch (sqle: SQLException)
         {
             val msg = sqle.message ?: ""
-            if (msg.contains("shutdown"))
+            if (!msg.contains("shutdown"))
             {
-                //Derby ALWAYS throws an exception on shutdown.
-                return true
+                logger.logSqlException("jdbc:derby:;shutdown=true", "jdbc:derby:;shutdown=true", sqle)
             }
 
-            logger.logSqlException("jdbc:derby:;shutdown=true", "jdbc:derby:;shutdown=true", sqle)
+            return false
         }
 
-        return false
+        return true
+    }
+
+    fun closeConnections()
+    {
+        hsConnections.forEach { it.close() }
+        hsConnections.clear()
     }
 
     fun deleteRowsFromTable(tableName: String, rowIds: List<String>): Boolean

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -291,7 +291,7 @@ class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = D
             val msg = sqle.message ?: ""
             if (!msg.contains("shutdown"))
             {
-                logger.logSqlException("jdbc:derby:;shutdown=true", "jdbc:derby:;shutdown=true", sqle)
+                logger.logSqlException("jdbc:derby:Databases/Darts;shutdown=true", "jdbc:derby:Databases/Darts;shutdown=true", sqle)
             }
 
             return false

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -25,7 +25,8 @@ val DATABASE_FILE_PATH: String = "${System.getProperty("user.dir")}/Databases"
 class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = DartsDatabaseUtil.DATABASE_NAME)
 {
     val localIdGenerator = LocalIdGenerator(this)
-    val hsConnections = mutableListOf<Connection>()
+
+    private val hsConnections = mutableListOf<Connection>()
     private val connectionPoolLock = Any()
     private var connectionCreateCount = 0
 
@@ -289,15 +290,15 @@ class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = D
         catch (sqle: SQLException)
         {
             val msg = sqle.message ?: ""
-            if (!msg.contains("shutdown"))
+            if (msg.contains("shutdown"))
             {
-                logger.logSqlException("jdbc:derby:Databases/Darts;shutdown=true", "jdbc:derby:Databases/Darts;shutdown=true", sqle)
+                return true
             }
 
-            return false
+            logger.logSqlException("jdbc:derby:Databases/Darts;shutdown=true", "jdbc:derby:Databases/Darts;shutdown=true", sqle)
         }
 
-        return true
+        return false
     }
 
     fun closeConnections()

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -349,9 +349,7 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
 
 fun Database.closeConnectionsAndDrop(dbName: String)
 {
-    hsConnections.forEach {
-        it.close()
-    }
+    closeConnections()
 
     try
     {


### PR DESCRIPTION
Towards the sync - turns out this was unnecessary. We can instead close connections, swap in the database and perform a more graceful restart within Derby (without killing the app).