### PR TITLE
DB directory refactor

### DIFF
--- a/src/main/kotlin/dartzee/core/util/FileUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/FileUtil.kt
@@ -111,17 +111,6 @@ object FileUtil
             null
         }
 
-    fun getAllContents(directory: File): List<File>
-    {
-        if (!directory.isDirectory)
-        {
-            throw FileSystemException(directory, reason = "$directory is not a directory")
-        }
-
-        val allFiles = directory.walk().toList()
-        return allFiles.filterNot { it == directory }
-    }
-
     /**
      * FileChooser
      */

--- a/src/main/kotlin/dartzee/core/util/FileUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/FileUtil.kt
@@ -111,6 +111,17 @@ object FileUtil
             null
         }
 
+    fun getAllContents(directory: File): List<File>
+    {
+        if (!directory.isDirectory)
+        {
+            throw FileSystemException(directory, reason = "$directory is not a directory")
+        }
+
+        val allFiles = directory.walk().toList()
+        return allFiles.filterNot { it == directory }
+    }
+
     /**
      * FileChooser
      */

--- a/src/main/kotlin/dartzee/core/util/FileUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/FileUtil.kt
@@ -1,6 +1,7 @@
 package dartzee.core.util
 
 import dartzee.logging.CODE_FILE_ERROR
+import dartzee.logging.CODE_SWITCHING_FILES
 import dartzee.utils.InjectedThings.logger
 import java.awt.Component
 import java.awt.Dimension
@@ -33,17 +34,21 @@ object FileUtil
         val oldFileName = oldFile.name
         val newFile = File(newFilePath)
         val zzOldFile = File(oldFile.parent, "zz$oldFileName")
+
+        logger.info(CODE_SWITCHING_FILES, "Rename current out of the way [$oldFile -> $zzOldFile]")
         if (oldFile.exists()
             && !oldFile.renameTo(zzOldFile))
         {
             return "Failed to rename old out of the way."
         }
 
+        logger.info(CODE_SWITCHING_FILES, "Rename new to current [$newFile -> $oldFile]")
         if (!newFile.renameTo(File(oldFile.parent, oldFileName)))
         {
             return "Failed to rename new file to $oldFileName"
         }
 
+        logger.info(CODE_SWITCHING_FILES, "Delete zz'd file [$zzOldFile]")
         if (!zzOldFile.deleteRecursively())
         {
             return "Failed to delete zz'd old file: ${zzOldFile.path}"

--- a/src/main/kotlin/dartzee/logging/LoggingCodes.kt
+++ b/src/main/kotlin/dartzee/logging/LoggingCodes.kt
@@ -46,6 +46,7 @@ val CODE_MERGE_STARTED = LoggingCode("mergeStarted")
 val CODE_MERGING_ENTITY = LoggingCode("mergingEntity")
 val CODE_ACHIEVEMENT_CONVERSION_STARTED = LoggingCode("achievementConversionStarted")
 val CODE_ACHIEVEMENT_CONVERSION_FINISHED = LoggingCode("achievementConversionFinished")
+val CODE_SWITCHING_FILES = LoggingCode("switchingFiles")
 
 //Warn
 val CODE_UNEXPECTED_ARGUMENT = LoggingCode("unexpectedArgument")

--- a/src/main/kotlin/dartzee/screen/ScreenCache.kt
+++ b/src/main/kotlin/dartzee/screen/ScreenCache.kt
@@ -10,7 +10,7 @@ object ScreenCache
 
     //Embedded screens
     val hmClassToScreen = mutableMapOf<Class<out EmbeddedScreen>, EmbeddedScreen>()
-    val syncSummaryPanel = SyncSummaryPanel()
+    var syncSummaryPanel = SyncSummaryPanel()
     val mainScreen = DartsApp(CheatBar())
 
     fun getDartsGameScreens() = hmGameIdToGameScreen.values.distinct()

--- a/src/main/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStore.kt
+++ b/src/main/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStore.kt
@@ -5,6 +5,7 @@ import dartzee.core.util.getFileTimeString
 import dartzee.logging.*
 import dartzee.screen.sync.SyncProgressDialog
 import dartzee.utils.AwsUtils
+import dartzee.utils.DATABASE_FILE_PATH
 import dartzee.utils.Database
 import dartzee.utils.InjectedThings.logger
 import net.lingala.zip4j.ZipFile
@@ -32,8 +33,10 @@ class AmazonS3RemoteDatabaseStore(private val bucketName: String): IRemoteDataba
 
         ZipFile(downloadPath).extractAll("$SYNC_DIR/original")
 
-        logger.info(CODE_UNZIPPED_DATABASE, "Unzipped database $remoteName to $SYNC_DIR/original")
-        return FetchDatabaseResult(Database("$SYNC_DIR/original/Databases"), s3Obj.lastModified)
+        File("$SYNC_DIR/original/Databases/Darts").copyTo(File("$DATABASE_FILE_PATH/DartsOther"))
+
+        logger.info(CODE_UNZIPPED_DATABASE, "Unzipped database $remoteName to $DATABASE_FILE_PATH/DartsOther")
+        return FetchDatabaseResult(Database("DartsOther"), s3Obj.lastModified)
     }
 
     override fun pushDatabase(remoteName: String, database: Database, lastModified: Date?)
@@ -44,7 +47,7 @@ class AmazonS3RemoteDatabaseStore(private val bucketName: String): IRemoteDataba
 
         lastModified?.let { verifyLastModifiedNotChanged(remoteName, lastModified) }
 
-        val dbDirectory = File(database.filePath)
+        val dbDirectory = File("$DATABASE_FILE_PATH/${database.dbName}")
         val zipFilePath = File("$SYNC_DIR/new.zip")
         val zip = ZipFile(zipFilePath).also { it.addFolder(dbDirectory) }
 

--- a/src/main/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStore.kt
+++ b/src/main/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStore.kt
@@ -10,6 +10,7 @@ import dartzee.utils.DATABASE_FILE_PATH
 import dartzee.utils.Database
 import dartzee.utils.InjectedThings.logger
 import net.lingala.zip4j.ZipFile
+import net.lingala.zip4j.model.ZipParameters
 import java.io.File
 import java.util.*
 import kotlin.ConcurrentModificationException
@@ -47,10 +48,10 @@ class AmazonS3RemoteDatabaseStore(private val bucketName: String): IRemoteDataba
         lastModified?.let { verifyLastModifiedNotChanged(remoteName, lastModified) }
 
         val dbDirectory = database.getDatabaseDirectory()
-        val contents = FileUtil.getAllContents(dbDirectory)
 
         val zipFilePath = File("$SYNC_DIR/new.zip")
-        val zip = ZipFile(zipFilePath).also { it.addFiles(contents) }
+        val params = ZipParameters().also { it.isIncludeRootFolder = false }
+        val zip = ZipFile(zipFilePath).also { it.addFolder(dbDirectory, params) }
 
         logger.info(CODE_ZIPPED_DATABASE, "Zipped up database to push to $remoteName - $zipFilePath")
 

--- a/src/main/kotlin/dartzee/sync/SyncManager.kt
+++ b/src/main/kotlin/dartzee/sync/SyncManager.kt
@@ -36,7 +36,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
         }
         finally
         {
-            File(SYNC_DIR).deleteRecursively()
+            tidyUpAllSyncDirs()
             SwingUtilities.invokeLater { DialogUtil.dismissLoadingDialog() }
             refreshSyncSummary()
         }
@@ -59,7 +59,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
         }
         finally
         {
-            File(SYNC_DIR).deleteRecursively()
+            tidyUpAllSyncDirs()
             SwingUtilities.invokeLater { DialogUtil.dismissLoadingDialog() }
             refreshSyncSummary()
         }
@@ -111,8 +111,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
         }
         finally
         {
-            File(SYNC_DIR).deleteRecursively()
-            File("$DATABASE_FILE_PATH/DartsOther").deleteRecursively()
+            tidyUpAllSyncDirs()
             SyncProgressDialog.dispose()
             refreshSyncSummary()
         }
@@ -120,10 +119,15 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
 
     private fun setUpSyncDir()
     {
-        File(SYNC_DIR).deleteRecursively()
+        tidyUpAllSyncDirs()
         File(SYNC_DIR).mkdirs()
     }
 
+    private fun tidyUpAllSyncDirs()
+    {
+        File(SYNC_DIR).deleteRecursively()
+        File("$DATABASE_FILE_PATH/DartsOther").deleteRecursively()
+    }
 
     private fun makeDatabaseMerger(remoteDatabase: Database, remoteName: String)
       = DatabaseMerger(mainDatabase, remoteDatabase, DatabaseMigrator(DatabaseMigrations.getConversionsMap()), remoteName)

--- a/src/main/kotlin/dartzee/sync/SyncManager.kt
+++ b/src/main/kotlin/dartzee/sync/SyncManager.kt
@@ -55,7 +55,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
 
             val remote = dbStore.fetchDatabase(remoteName).database
             SyncAuditEntity.insertSyncAudit(remote, remoteName)
-            DartsDatabaseUtil.swapInDatabase(remote.getDatabaseDirectory())
+            DartsDatabaseUtil.swapInDatabase(remote)
         }
         finally
         {
@@ -91,7 +91,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
 
             SyncProgressDialog.progressToStage(SyncStage.OVERWRITE_LOCAL)
 
-            val success = DartsDatabaseUtil.swapInDatabase(resultingDatabase.getDatabaseDirectory())
+            val success = DartsDatabaseUtil.swapInDatabase(resultingDatabase)
             SyncProgressDialog.dispose()
             if (success)
             {

--- a/src/main/kotlin/dartzee/sync/SyncManager.kt
+++ b/src/main/kotlin/dartzee/sync/SyncManager.kt
@@ -6,6 +6,7 @@ import dartzee.db.DatabaseMerger
 import dartzee.db.DatabaseMigrator
 import dartzee.db.SyncAuditEntity
 import dartzee.screen.sync.SyncProgressDialog
+import dartzee.utils.DATABASE_FILE_PATH
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.Database
 import dartzee.utils.DatabaseMigrations
@@ -54,7 +55,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
 
             val remote = dbStore.fetchDatabase(remoteName).database
             SyncAuditEntity.insertSyncAudit(remote, remoteName)
-            DartsDatabaseUtil.swapInDatabase(File(remote.filePath))
+            DartsDatabaseUtil.swapInDatabase(remote.getDatabaseDirectory())
         }
         finally
         {
@@ -90,7 +91,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
 
             SyncProgressDialog.progressToStage(SyncStage.OVERWRITE_LOCAL)
 
-            val success = DartsDatabaseUtil.swapInDatabase(File(resultingDatabase.filePath))
+            val success = DartsDatabaseUtil.swapInDatabase(resultingDatabase.getDatabaseDirectory())
             SyncProgressDialog.dispose()
             if (success)
             {
@@ -111,6 +112,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore)
         finally
         {
             File(SYNC_DIR).deleteRecursively()
+            File("$DATABASE_FILE_PATH/DartsOther").deleteRecursively()
             SyncProgressDialog.dispose()
             refreshSyncSummary()
         }

--- a/src/main/kotlin/dartzee/sync/SyncUtils.kt
+++ b/src/main/kotlin/dartzee/sync/SyncUtils.kt
@@ -5,6 +5,7 @@ import dartzee.db.GameEntity
 import dartzee.db.SyncAuditEntity
 import dartzee.screen.ScreenCache
 import dartzee.utils.InjectedThings
+import dartzee.utils.InjectedThings.mainDatabase
 import dartzee.utils.PREFERENCES_STRING_REMOTE_DATABASE_NAME
 import dartzee.utils.PreferenceUtil
 
@@ -28,21 +29,25 @@ data class SyncConfig(val mode: SyncMode, val remoteName: String)
 data class SyncSummary(val remoteName: String, val lastSynced: String, val pendingGames: String)
 fun refreshSyncSummary()
 {
-    val remoteName = getRemoteName()
-    val syncSummary = if (remoteName.isEmpty())
+    val version = mainDatabase.getDatabaseVersion() ?: return
+    if (version >= 16)
     {
-        SyncSummary("Unset", "-", "-")
-    }
-    else
-    {
-        val dtLastSynced = SyncAuditEntity.getLastSyncDate(InjectedThings.mainDatabase, remoteName)
-        val lastSyncDesc = dtLastSynced?.formatTimestamp() ?: "-"
-        val pendingGameCount = GameEntity().countModifiedSince(dtLastSynced)
+        val remoteName = getRemoteName()
+        val syncSummary = if (remoteName.isEmpty())
+        {
+            SyncSummary("Unset", "-", "-")
+        }
+        else
+        {
+            val dtLastSynced = SyncAuditEntity.getLastSyncDate(InjectedThings.mainDatabase, remoteName)
+            val lastSyncDesc = dtLastSynced?.formatTimestamp() ?: "-"
+            val pendingGameCount = GameEntity().countModifiedSince(dtLastSynced)
 
-        SyncSummary(remoteName, lastSyncDesc, "$pendingGameCount")
-    }
+            SyncSummary(remoteName, lastSyncDesc, "$pendingGameCount")
+        }
 
-    ScreenCache.syncSummaryPanel.refreshSummary(syncSummary)
+        ScreenCache.syncSummaryPanel.refreshSummary(syncSummary)
+    }
 }
 
 fun resetRemote()

--- a/src/main/kotlin/dartzee/sync/SyncUtils.kt
+++ b/src/main/kotlin/dartzee/sync/SyncUtils.kt
@@ -4,7 +4,6 @@ import dartzee.core.util.formatTimestamp
 import dartzee.db.GameEntity
 import dartzee.db.SyncAuditEntity
 import dartzee.screen.ScreenCache
-import dartzee.utils.InjectedThings
 import dartzee.utils.InjectedThings.mainDatabase
 import dartzee.utils.PREFERENCES_STRING_REMOTE_DATABASE_NAME
 import dartzee.utils.PreferenceUtil
@@ -39,7 +38,7 @@ fun refreshSyncSummary()
         }
         else
         {
-            val dtLastSynced = SyncAuditEntity.getLastSyncDate(InjectedThings.mainDatabase, remoteName)
+            val dtLastSynced = SyncAuditEntity.getLastSyncDate(mainDatabase, remoteName)
             val lastSyncDesc = dtLastSynced?.formatTimestamp() ?: "-"
             val pendingGameCount = GameEntity().countModifiedSince(dtLastSynced)
 

--- a/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
+++ b/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
@@ -1,5 +1,5 @@
 package dartzee.utils
 
-const val DARTS_VERSION_NUMBER = "v4.6.1"
+const val DARTS_VERSION_NUMBER = "v5.0.0-BETA"
 const val DARTZEE_REPOSITORY_URL = "https://api.github.com/repos/alexburlton/Dartzee"
 const val DARTZEE_MANUAL_DOWNLOAD_URL = "https://github.com/alexburlton/Dartzee/releases"

--- a/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
+++ b/src/main/kotlin/dartzee/utils/ApplicationConstants.kt
@@ -1,5 +1,5 @@
 package dartzee.utils
 
-const val DARTS_VERSION_NUMBER = "v5.0.0-BETA"
+const val DARTS_VERSION_NUMBER = "v4.6.1"
 const val DARTZEE_REPOSITORY_URL = "https://api.github.com/repos/alexburlton/Dartzee"
 const val DARTZEE_MANUAL_DOWNLOAD_URL = "https://github.com/alexburlton/Dartzee/releases"

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -134,29 +134,20 @@ object DartsDatabaseUtil {
         {
             return
         }
-
-        if (swapInDatabase(directoryFrom))
-        {
-            DialogUtil.showInfo("Database successfully restored!")
-        }
     }
 
-    fun swapInDatabase(directoryFrom: File): Boolean
+    fun swapInDatabase(otherDatabase: Database): Boolean
     {
-        val success = directoryFrom.copyRecursively(File(DATABASE_FILE_PATH_TEMP), true)
-        if (!success)
-        {
-            DialogUtil.showError("Restore failed - failed to copy the new database files.")
-            return false
-        }
-
         //Now switch it in
         try
         {
             mainDatabase.closeConnections()
             mainDatabase.shutDown()
 
-            val error = FileUtil.swapInFile(DATABASE_FILE_PATH, DATABASE_FILE_PATH_TEMP)
+            otherDatabase.closeConnections()
+            otherDatabase.shutDown()
+
+            val error = FileUtil.swapInFile(mainDatabase.getDatabaseDirectory().toString(), otherDatabase.getDatabaseDirectory().toString())
             if (error != null)
             {
                 DialogUtil.showError("Failed to restore database. Error: $error")

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -24,8 +24,6 @@ object DartsDatabaseUtil {
     const val DATABASE_VERSION = 16
     const val DATABASE_NAME = "Darts"
 
-    private val DATABASE_FILE_PATH_TEMP = DATABASE_FILE_PATH + "_copying"
-
     fun getAllEntities(database: Database = mainDatabase): List<AbstractEntity<*>> {
         return listOf(
             PlayerEntity(database),
@@ -147,7 +145,7 @@ object DartsDatabaseUtil {
             otherDatabase.closeConnections()
             otherDatabase.shutDown()
 
-            val error = FileUtil.swapInFile(mainDatabase.getDatabaseDirectory().toString(), otherDatabase.getDatabaseDirectory().toString())
+            val error = FileUtil.swapInFile(mainDatabase.getDirectoryStr(), otherDatabase.getDirectoryStr())
             if (error != null)
             {
                 DialogUtil.showError("Failed to restore database. Error: $error")

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -1,5 +1,6 @@
 package dartzee.utils
 
+import dartzee.`object`.DartsClient
 import dartzee.core.util.DialogUtil
 import dartzee.core.util.FileUtil
 import dartzee.db.*
@@ -19,28 +20,28 @@ import kotlin.system.exitProcess
 /**
  * Database helpers specific to Dartzee, e.g. first time initialisation
  */
-object DartsDatabaseUtil
-{
+object DartsDatabaseUtil {
     const val DATABASE_VERSION = 16
     const val DATABASE_NAME = "Darts"
 
     private val DATABASE_FILE_PATH_TEMP = DATABASE_FILE_PATH + "_copying"
 
-    fun getAllEntities(database: Database = mainDatabase): List<AbstractEntity<*>>
-    {
-        return listOf(PlayerEntity(database),
-                DartEntity(database),
-                GameEntity(database),
-                ParticipantEntity(database),
-                PlayerImageEntity(database),
-                DartsMatchEntity(database),
-                AchievementEntity(database),
-                DartzeeRuleEntity(database),
-                DartzeeTemplateEntity(database),
-                DartzeeRoundResultEntity(database),
-                X01FinishEntity(database),
-                PendingLogsEntity(database),
-                SyncAuditEntity(database))
+    fun getAllEntities(database: Database = mainDatabase): List<AbstractEntity<*>> {
+        return listOf(
+            PlayerEntity(database),
+            DartEntity(database),
+            GameEntity(database),
+            ParticipantEntity(database),
+            PlayerImageEntity(database),
+            DartsMatchEntity(database),
+            AchievementEntity(database),
+            DartzeeRuleEntity(database),
+            DartzeeTemplateEntity(database),
+            DartzeeRoundResultEntity(database),
+            X01FinishEntity(database),
+            PendingLogsEntity(database),
+            SyncAuditEntity(database)
+        )
     }
 
     fun getAllEntitiesIncludingVersion(database: Database = mainDatabase) =
@@ -48,7 +49,7 @@ object DartsDatabaseUtil
 
     fun initialiseDatabase(database: Database)
     {
-        DriverManager.registerDriver(EmbeddedDriver())
+        initialiseDerby()
 
         DialogUtil.showLoadingDialog("Checking database status...")
 
@@ -67,6 +68,16 @@ object DartsDatabaseUtil
         migrateDatabase(migrator, database)
 
         refreshSyncSummary()
+    }
+
+    private fun initialiseDerby()
+    {
+        DriverManager.registerDriver(EmbeddedDriver())
+
+        val p = System.getProperties()
+        p.setProperty("derby.system.home", DATABASE_FILE_PATH)
+        p.setProperty("derby.language.logStatementText", "${DartsClient.devMode}")
+        p.setProperty("derby.language.logQueryPlan", "${DartsClient.devMode}")
     }
 
     fun migrateDatabase(migrator: DatabaseMigrator, database: Database)

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -22,7 +22,7 @@ import kotlin.system.exitProcess
 object DartsDatabaseUtil
 {
     const val DATABASE_VERSION = 16
-    const val DATABASE_NAME = "jdbc:derby:Databases/Darts;create=true"
+    const val DATABASE_NAME = "Darts"
 
     private val DATABASE_FILE_PATH_TEMP = DATABASE_FILE_PATH + "_copying"
 
@@ -132,7 +132,6 @@ object DartsDatabaseUtil
 
     fun swapInDatabase(directoryFrom: File): Boolean
     {
-        //Copy the files to a temporary file path in the application directory - Databases_copying.
         val success = directoryFrom.copyRecursively(File(DATABASE_FILE_PATH_TEMP), true)
         if (!success)
         {
@@ -173,15 +172,6 @@ object DartsDatabaseUtil
         if (name != "Databases")
         {
             DialogUtil.showError("Selected path is not valid - you must select a folder named 'Databases'")
-            return null
-        }
-
-        //Test we can connect
-        val otherDatabase = Database(filePath = directoryFrom.absolutePath)
-        val testSuccess = otherDatabase.testConnection()
-        if (!testSuccess)
-        {
-            DialogUtil.showError("Testing connection failed for the selected database. Cannot restore from this location.")
             return null
         }
 

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -79,14 +79,15 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
         return connection
     }
 
-    private fun getDbStringForNewConnection() =
+    private fun getDbStringForNewConnection() = "${getQualifiedDbName()};create=true"
+    private fun getQualifiedDbName() =
         if (inMemory)
         {
-            "jdbc:derby:memory:Databases/$dbName;create=true"
+            "jdbc:derby:memory:Databases/$dbName"
         }
         else
         {
-            "jdbc:derby:Databases/$dbName;create=true"
+            "jdbc:derby:Databases/$dbName"
         }
 
     private fun getProps(): Properties
@@ -300,9 +301,11 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
 
     fun shutDown(): Boolean
     {
+        val command = "${getQualifiedDbName()};shutdown=true"
+
         try
         {
-            DriverManager.getConnection("jdbc:derby:Databases/$dbName;shutdown=true", getProps())
+            DriverManager.getConnection(command, getProps())
         }
         catch (sqle: SQLException)
         {
@@ -312,7 +315,7 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
                 return true
             }
 
-            logger.logSqlException("jdbc:derby:Databases/$dbName;shutdown=true", "jdbc:derby:Databases/$dbName;shutdown=true", sqle)
+            logger.logSqlException(command, command, sqle)
         }
 
         return false

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -93,7 +93,8 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
         return props
     }
 
-    fun getDatabaseDirectory() = File("$DATABASE_FILE_PATH/$dbName")
+    fun getDirectoryStr() = "$DATABASE_FILE_PATH/$dbName"
+    fun getDirectory() = File(getDirectoryStr())
 
     fun executeUpdates(statements: List<String>): Boolean
     {

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -75,7 +75,7 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
     }
 
     private fun getDbStringForNewConnection() = "${getQualifiedDbName()};create=true"
-    private fun getQualifiedDbName() =
+    fun getQualifiedDbName() =
         if (inMemory)
         {
             "jdbc:derby:memory:Databases/$dbName"

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -69,11 +69,6 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
     {
         connectionCreateCount++
 
-        val p = System.getProperties()
-        p.setProperty("derby.system.home", DATABASE_FILE_PATH)
-        p.setProperty("derby.language.logStatementText", "${DartsClient.devMode}")
-        p.setProperty("derby.language.logQueryPlan", "${DartsClient.devMode}")
-
         val connection = DriverManager.getConnection(getDbStringForNewConnection(), getProps())
         logger.info(CODE_NEW_CONNECTION, "Created new connection. Total created: $connectionCreateCount, pool size: ${hsConnections.size}")
         return connection

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -7,6 +7,7 @@ import dartzee.db.VersionEntity
 import dartzee.logging.*
 import dartzee.logging.exceptions.WrappedSqlException
 import dartzee.utils.InjectedThings.logger
+import java.io.File
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.ResultSet
@@ -22,7 +23,7 @@ val DATABASE_FILE_PATH: String = "${System.getProperty("user.dir")}/Databases"
 /**
  * Generic derby helper methods
  */
-class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = DartsDatabaseUtil.DATABASE_NAME)
+class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val inMemory: Boolean = false)
 {
     val localIdGenerator = LocalIdGenerator(this)
 
@@ -64,23 +65,39 @@ class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = D
         }
     }
 
-    private fun createDatabaseConnection(dbName: String = this.dbName): Connection
+    private fun createDatabaseConnection(): Connection
     {
         connectionCreateCount++
 
         val p = System.getProperties()
-        p.setProperty("derby.system.home", filePath)
+        p.setProperty("derby.system.home", DATABASE_FILE_PATH)
         p.setProperty("derby.language.logStatementText", "${DartsClient.devMode}")
         p.setProperty("derby.language.logQueryPlan", "${DartsClient.devMode}")
 
-        val props = Properties()
-        props["user"] = "administrator"
-        props["password"] = "wallace"
-
-        val connection = DriverManager.getConnection(dbName, props)
+        val connection = DriverManager.getConnection(getDbStringForNewConnection(), getProps())
         logger.info(CODE_NEW_CONNECTION, "Created new connection. Total created: $connectionCreateCount, pool size: ${hsConnections.size}")
         return connection
     }
+
+    private fun getDbStringForNewConnection() =
+        if (inMemory)
+        {
+            "jdbc:derby:memory:Databases/$dbName;create=true"
+        }
+        else
+        {
+            "jdbc:derby:Databases/$dbName;create=true"
+        }
+
+    private fun getProps(): Properties
+    {
+        val props = Properties()
+        props["user"] = "administrator"
+        props["password"] = "wallace"
+        return props
+    }
+
+    fun getDatabaseDirectory() = File("$DATABASE_FILE_PATH/$dbName")
 
     fun executeUpdates(statements: List<String>): Boolean
     {
@@ -274,7 +291,7 @@ class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = D
         }
         catch (t: Throwable)
         {
-            logger.error(CODE_TEST_CONNECTION_ERROR, "Failed to establish test connection for path $filePath", t)
+            logger.error(CODE_TEST_CONNECTION_ERROR, "Failed to establish test connection for path $DATABASE_FILE_PATH/$dbName", t)
             return false
         }
 
@@ -285,7 +302,7 @@ class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = D
     {
         try
         {
-            createDatabaseConnection(dbName = "jdbc:derby:Databases/Darts;shutdown=true")
+            DriverManager.getConnection("jdbc:derby:Databases/$dbName;shutdown=true", getProps())
         }
         catch (sqle: SQLException)
         {
@@ -295,7 +312,7 @@ class Database(val filePath: String = DATABASE_FILE_PATH, val dbName: String = D
                 return true
             }
 
-            logger.logSqlException("jdbc:derby:Databases/Darts;shutdown=true", "jdbc:derby:Databases/Darts;shutdown=true", sqle)
+            logger.logSqlException("jdbc:derby:Databases/$dbName;shutdown=true", "jdbc:derby:Databases/$dbName;shutdown=true", sqle)
         }
 
         return false

--- a/src/test/kotlin/dartzee/achievements/AbstractAchievementTest.kt
+++ b/src/test/kotlin/dartzee/achievements/AbstractAchievementTest.kt
@@ -26,7 +26,7 @@ abstract class AbstractAchievementTest<E: AbstractAchievement>: AbstractTest()
 {
     override fun beforeEachTest()
     {
-        mainDatabase = Database(dbName = DATABASE_NAME_TEST)
+        mainDatabase = Database(inMemory = true)
         mainDatabase.dropUnexpectedTables()
         super.beforeEachTest()
     }

--- a/src/test/kotlin/dartzee/core/util/TestFileUtil.kt
+++ b/src/test/kotlin/dartzee/core/util/TestFileUtil.kt
@@ -4,7 +4,6 @@ import dartzee.helper.AbstractTest
 import dartzee.logging.CODE_FILE_ERROR
 import dartzee.logging.Severity
 import io.kotlintest.matchers.collections.shouldContainExactly
-import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import org.junit.Test
@@ -120,26 +119,4 @@ class TestFileUtil: AbstractTest()
         ii.iconWidth shouldBe 150
         ii.iconHeight shouldBe 150
     }
-
-    @Test
-    fun `Should list all contents of a directory, excluding the directory itself`()
-    {
-        val a = File("Test/A/")
-        val b = File("Test/B/")
-
-        val rootFile = File("Test/root.txt")
-        val aFile = File("Test/A/a.txt")
-        val bFile = File("Test/B/b.txt")
-
-        a.mkdirs()
-        b.mkdirs()
-
-        rootFile.createNewFile()
-        aFile.createNewFile()
-        bFile.createNewFile()
-
-        val results = FileUtil.getAllContents(TEST_DIR)
-        results.shouldContainExactlyInAnyOrder(a, b, rootFile, aFile, bFile)
-    }
-
 }

--- a/src/test/kotlin/dartzee/core/util/TestFileUtil.kt
+++ b/src/test/kotlin/dartzee/core/util/TestFileUtil.kt
@@ -4,6 +4,7 @@ import dartzee.helper.AbstractTest
 import dartzee.logging.CODE_FILE_ERROR
 import dartzee.logging.Severity
 import io.kotlintest.matchers.collections.shouldContainExactly
+import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.matchers.types.shouldBeInstanceOf
 import io.kotlintest.shouldBe
 import org.junit.Test
@@ -14,14 +15,29 @@ import javax.swing.ImageIcon
 
 class TestFileUtil: AbstractTest()
 {
+    private val TEST_DIR = File("Test/")
+
+    override fun beforeEachTest()
+    {
+        super.beforeEachTest()
+        TEST_DIR.deleteRecursively()
+        TEST_DIR.mkdirs()
+    }
+
+    override fun afterEachTest()
+    {
+        super.afterEachTest()
+        TEST_DIR.deleteRecursively()
+    }
+
     @Test
     fun `Should successfully delete a file`()
     {
-        val f = File("Test.txt")
+        val f = File("Test/Test.txt")
         f.createNewFile()
         f.exists() shouldBe true
 
-        val result = FileUtil.deleteFileIfExists("Test.txt")
+        val result = FileUtil.deleteFileIfExists("Test/Test.txt")
         result shouldBe true
         f.exists() shouldBe false
     }
@@ -36,11 +52,7 @@ class TestFileUtil: AbstractTest()
     @Test
     fun `Should stack trace and return false if the deletion fails`()
     {
-        val dir = File("Test/")
-        dir.mkdirs()
-
         val f = File("Test/File.txt")
-        f.mkdirs()
         f.createNewFile()
 
         FileUtil.deleteFileIfExists("Test") shouldBe false
@@ -48,19 +60,16 @@ class TestFileUtil: AbstractTest()
         val log = verifyLog(CODE_FILE_ERROR, Severity.ERROR)
         log.message shouldBe "Failed to delete file Test"
         log.errorObject?.shouldBeInstanceOf<DirectoryNotEmptyException>()
-
-        //Tidy up
-        dir.deleteRecursively()
     }
 
     @Test
     fun `Should swap in a file successfully`()
     {
-        val current = File("Current.txt")
+        val current = File("Test/Current.txt")
         current.createNewFile()
         current.writeText("Current")
 
-        val new = File("New.txt")
+        val new = File("Test/New.txt")
         new.createNewFile()
         new.writeText("New")
 
@@ -69,33 +78,27 @@ class TestFileUtil: AbstractTest()
         new.exists() shouldBe false
         current.exists() shouldBe true
         current.readLines().shouldContainExactly("New")
-
-        //Tidy up
-        current.delete()
     }
 
     @Test
     fun `Should swap in a directory successfully`()
     {
-        File("Current").mkdir()
-        File("New").mkdir()
+        File("Test/Current").mkdir()
+        File("Test/New").mkdir()
 
-        val current = File("Current/File.txt")
+        val current = File("Test/Current/File.txt")
         current.createNewFile()
         current.writeText("Current")
 
-        val new = File("New/File.txt")
+        val new = File("Test/New/File.txt")
         new.createNewFile()
         new.writeText("New")
 
-        FileUtil.swapInFile("Current", "New")
+        FileUtil.swapInFile("Test/Current", "Test/New")
 
         new.exists() shouldBe false
         current.exists() shouldBe true
         current.readLines().shouldContainExactly("New")
-
-        //Tidy up
-        File("Current").deleteRecursively()
     }
 
     @Test
@@ -117,4 +120,26 @@ class TestFileUtil: AbstractTest()
         ii.iconWidth shouldBe 150
         ii.iconHeight shouldBe 150
     }
+
+    @Test
+    fun `Should list all contents of a directory, excluding the directory itself`()
+    {
+        val a = File("Test/A/")
+        val b = File("Test/B/")
+
+        val rootFile = File("Test/root.txt")
+        val aFile = File("Test/A/a.txt")
+        val bFile = File("Test/B/b.txt")
+
+        a.mkdirs()
+        b.mkdirs()
+
+        rootFile.createNewFile()
+        aFile.createNewFile()
+        bFile.createNewFile()
+
+        val results = FileUtil.getAllContents(TEST_DIR)
+        results.shouldContainExactlyInAnyOrder(a, b, rootFile, aFile, bFile)
+    }
+
 }

--- a/src/test/kotlin/dartzee/db/TestDatabaseMerger.kt
+++ b/src/test/kotlin/dartzee/db/TestDatabaseMerger.kt
@@ -8,7 +8,6 @@ import dartzee.core.util.getSqlDateNow
 import dartzee.game.GameType
 import dartzee.helper.*
 import dartzee.logging.CODE_MERGE_ERROR
-import dartzee.logging.CODE_TEST_CONNECTION_ERROR
 import dartzee.logging.Severity
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.Database
@@ -28,12 +27,11 @@ class TestDatabaseMerger: AbstractTest()
     @Test
     fun `Should return false if connecting to remote database fails`()
     {
-        val remoteName = "jdbc:derby:memory:invalid;create=false"
-        val remoteDatabase = Database("invalid", remoteName)
+        val remote = mockk<Database>()
+        every { remote.testConnection() } returns false
 
-        val merger = makeDatabaseMerger(remoteDatabase = remoteDatabase)
+        val merger = makeDatabaseMerger(remoteDatabase = remote)
         merger.validateMerge() shouldBe false
-        verifyLog(CODE_TEST_CONNECTION_ERROR, Severity.ERROR)
         dialogFactory.errorsShown.shouldContainExactly("An error occurred connecting to the remote database.")
     }
 

--- a/src/test/kotlin/dartzee/db/TestDatabaseMigrations.kt
+++ b/src/test/kotlin/dartzee/db/TestDatabaseMigrations.kt
@@ -2,7 +2,6 @@ package dartzee.db
 
 import dartzee.core.helper.verifyNotCalled
 import dartzee.helper.AbstractTest
-import dartzee.helper.DATABASE_NAME_TEST
 import dartzee.helper.usingInMemoryDatabase
 import dartzee.utils.Database
 import dartzee.utils.DatabaseMigrations
@@ -15,7 +14,7 @@ class TestDatabaseMigrations: AbstractTest()
 {
     override fun beforeEachTest()
     {
-        InjectedThings.mainDatabase = Database(dbName = DATABASE_NAME_TEST)
+        InjectedThings.mainDatabase = Database(inMemory = true)
         super.beforeEachTest()
     }
 

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -22,7 +22,6 @@ import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import kotlin.test.assertNotNull
 
-const val DATABASE_NAME_TEST = "jdbc:derby:memory:Darts;create=true"
 private var doneOneTimeSetup = false
 private val logDestination = FakeLogDestination()
 val logger = Logger(listOf(logDestination, LogDestinationSystemOut()))
@@ -63,7 +62,7 @@ abstract class AbstractTest
         InjectedThings.clock = Clock.fixed(CURRENT_TIME, ZoneId.of("UTC"))
 
         UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel")
-        mainDatabase = Database(dbName = DATABASE_NAME_TEST)
+        mainDatabase = Database(inMemory = true)
         DartsDatabaseUtil.initialiseDatabase(mainDatabase)
     }
 

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -11,9 +11,7 @@ import dartzee.db.*
 import dartzee.game.GameType
 import dartzee.game.MatchMode
 import dartzee.logging.LoggingCode
-import dartzee.utils.DATABASE_FILE_PATH
 import dartzee.utils.Database
-import dartzee.utils.InjectedThings
 import dartzee.utils.InjectedThings.mainDatabase
 import java.sql.DriverManager
 import java.sql.SQLException
@@ -319,18 +317,16 @@ fun retrieveAchievementsForPlayer(playerId: String): List<AchievementSummary>
     return achievements.map { AchievementSummary(it.achievementType, it.achievementCounter, it.gameIdEarned, it.achievementDetail) }
 }
 
-private fun makeInMemoryDatabase(dbName: String = UUID.randomUUID().toString(), filePath: String = DATABASE_FILE_PATH): Database
+private fun makeInMemoryDatabase(dbName: String = UUID.randomUUID().toString()): Database
 {
-    val fullName = "jdbc:derby:memory:$dbName;create=true"
-    return Database(filePath = filePath, dbName = fullName).also { it.initialiseConnectionPool(5) }
+    return Database(dbName = dbName, inMemory = true).also { it.initialiseConnectionPool(5) }
 }
 
 fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
-                          filePath: String = DATABASE_FILE_PATH,
                           withSchema: Boolean = false,
                           testBlock: (inMemoryDatabase: Database) -> Unit)
 {
-    val db = makeInMemoryDatabase(dbName, filePath)
+    val db = makeInMemoryDatabase(dbName)
     try
     {
         if (withSchema)
@@ -359,7 +355,7 @@ fun Database.closeConnectionsAndDrop(dbName: String)
     {
         if (sqle.message != "Database 'memory:$dbName' dropped.")
         {
-            InjectedThings.logger.info(LoggingCode("dropInMemoryDatabase"), "Caught: ${sqle.message}")
+            logger.info(LoggingCode("dropInMemoryDatabase"), "Caught: ${sqle.message}")
         }
     }
 }

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -329,6 +329,8 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
     val db = makeInMemoryDatabase(dbName)
     try
     {
+        db.getDatabaseDirectory().mkdirs()
+
         if (withSchema)
         {
             val migrator = DatabaseMigrator(emptyMap())
@@ -339,6 +341,7 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
     }
     finally
     {
+        db.getDatabaseDirectory().deleteRecursively()
         db.closeConnectionsAndDrop(dbName)
     }
 }
@@ -346,6 +349,7 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
 fun Database.closeConnectionsAndDrop(dbName: String)
 {
     closeConnections()
+    shutDown()
 
     try
     {

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -329,7 +329,7 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
     val db = makeInMemoryDatabase(dbName)
     try
     {
-        db.getDatabaseDirectory().mkdirs()
+        db.getDirectory().mkdirs()
 
         if (withSchema)
         {
@@ -341,7 +341,7 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
     }
     finally
     {
-        db.getDatabaseDirectory().deleteRecursively()
+        db.getDirectory().deleteRecursively()
         db.closeConnectionsAndDrop(dbName)
     }
 }
@@ -349,7 +349,6 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
 fun Database.closeConnectionsAndDrop(dbName: String)
 {
     closeConnections()
-    shutDown()
 
     try
     {

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -349,16 +349,17 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
 fun Database.closeConnectionsAndDrop(dbName: String)
 {
     closeConnections()
+    shutDown()
 
     try
     {
-        DriverManager.getConnection("jdbc:derby:memory:$dbName;drop=true")
+        DriverManager.getConnection("${getQualifiedDbName()};drop=true")
     }
     catch (sqle: SQLException)
     {
-        if (sqle.message != "Database 'memory:$dbName' dropped.")
+        if (sqle.message != "Database 'memory:Databases/$dbName' dropped.")
         {
-            logger.info(LoggingCode("dropInMemoryDatabase"), "Caught: ${sqle.message}")
+            logger.error(LoggingCode("dropInMemoryDatabase"), "Caught: ${sqle.message}")
         }
     }
 }

--- a/src/test/kotlin/dartzee/helper/SyncAssertions.kt
+++ b/src/test/kotlin/dartzee/helper/SyncAssertions.kt
@@ -1,17 +1,19 @@
 package dartzee.helper
 
 import dartzee.screen.ScreenCache
-import dartzee.sync.refreshSyncSummary
-import dartzee.sync.saveRemoteName
-import io.kotlintest.matchers.string.shouldContain
+import dartzee.screen.sync.SyncSummaryPanel
+import dartzee.utils.DartsDatabaseUtil
+import dartzee.utils.InjectedThings.mainDatabase
+import io.mockk.mockk
+import io.mockk.verify
 
 fun shouldUpdateSyncSummary(testFn: () -> Unit)
 {
-    saveRemoteName("")
-    refreshSyncSummary()
+    mainDatabase.updateDatabaseVersion(DartsDatabaseUtil.DATABASE_VERSION)
+    val summaryPanelMock = mockk<SyncSummaryPanel>(relaxed = true)
+    ScreenCache.syncSummaryPanel = summaryPanelMock
 
-    saveRemoteName("Goomba")
     testFn()
 
-    ScreenCache.syncSummaryPanel.text.shouldContain("Goomba")
+    verify { summaryPanelMock.refreshSummary(any()) }
 }

--- a/src/test/kotlin/dartzee/helper/SyncAssertions.kt
+++ b/src/test/kotlin/dartzee/helper/SyncAssertions.kt
@@ -9,11 +9,20 @@ import io.mockk.verify
 
 fun shouldUpdateSyncSummary(testFn: () -> Unit)
 {
-    mainDatabase.updateDatabaseVersion(DartsDatabaseUtil.DATABASE_VERSION)
-    val summaryPanelMock = mockk<SyncSummaryPanel>(relaxed = true)
-    ScreenCache.syncSummaryPanel = summaryPanelMock
+    val originalPanel = ScreenCache.syncSummaryPanel
 
-    testFn()
+    try
+    {
+        mainDatabase.updateDatabaseVersion(DartsDatabaseUtil.DATABASE_VERSION)
+        val summaryPanelMock = mockk<SyncSummaryPanel>(relaxed = true)
+        ScreenCache.syncSummaryPanel = summaryPanelMock
 
-    verify { summaryPanelMock.refreshSummary(any()) }
+        testFn()
+
+        verify { summaryPanelMock.refreshSummary(any()) }
+    }
+    finally
+    {
+        ScreenCache.syncSummaryPanel = originalPanel
+    }
 }

--- a/src/test/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStoreTest.kt
+++ b/src/test/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStoreTest.kt
@@ -43,7 +43,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
             val store = AmazonS3RemoteDatabaseStore("dartzee-unit-test")
             val remoteName = UUID.randomUUID().toString()
 
-            val dbFile = File("${db.getDatabaseDirectory()}/Test.txt")
+            val dbFile = File("${db.getDirectory()}/Test.txt")
             dbFile.createNewFile()
             dbFile.writeText(testFileText)
 
@@ -77,7 +77,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
         val s3Client = AwsUtils.makeS3Client()
 
         usingInMemoryDatabase(withSchema = true) { db ->
-            File("${db.getDatabaseDirectory()}/Test.txt").createNewFile()
+            File("${db.getDirectory()}/Test.txt").createNewFile()
 
             val store = AmazonS3RemoteDatabaseStore("dartzee-unit-test")
             val remoteName = UUID.randomUUID().toString()
@@ -95,7 +95,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
         Assume.assumeNotNull(AwsUtils.readCredentials("AWS_SYNC"))
 
         usingInMemoryDatabase(withSchema = true) { db ->
-            val dbFile = File("${db.getDatabaseDirectory()}/Test.txt")
+            val dbFile = File("${db.getDirectory()}/Test.txt")
             dbFile.createNewFile()
 
             val store = AmazonS3RemoteDatabaseStore("dartzee-unit-test")

--- a/src/test/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStoreTest.kt
+++ b/src/test/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStoreTest.kt
@@ -3,6 +3,7 @@ package dartzee.sync
 import dartzee.helper.AbstractTest
 import dartzee.helper.usingInMemoryDatabase
 import dartzee.utils.AwsUtils
+import dartzee.utils.DATABASE_FILE_PATH
 import dartzee.utils.DartsDatabaseUtil.DATABASE_VERSION
 import io.kotlintest.matchers.file.shouldExist
 import io.kotlintest.matchers.string.shouldContain
@@ -32,6 +33,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
         super.afterEachTest()
 
         File(SYNC_DIR).deleteRecursively()
+        File("$DATABASE_FILE_PATH/DartsOther").deleteRecursively()
     }
 
     @Test
@@ -42,6 +44,11 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
         usingInMemoryDatabase(withSchema = true) { db ->
             val store = AmazonS3RemoteDatabaseStore("dartzee-unit-test")
             val remoteName = UUID.randomUUID().toString()
+
+            val dbFile = File("${db.getDatabaseDirectory()}/Test.txt")
+            dbFile.createNewFile()
+            dbFile.writeText(testFileText)
+
             store.pushDatabase(remoteName, db, null)
 
             store.databaseExists(remoteName) shouldBe true

--- a/src/test/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStoreTest.kt
+++ b/src/test/kotlin/dartzee/sync/AmazonS3RemoteDatabaseStoreTest.kt
@@ -39,7 +39,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
     {
         Assume.assumeNotNull(AwsUtils.readCredentials("aws-sync"))
 
-        usingInMemoryDatabase(filePath = "$SYNC_DIR/Databases", withSchema = true) { db ->
+        usingInMemoryDatabase(withSchema = true) { db ->
             val store = AmazonS3RemoteDatabaseStore("dartzee-unit-test")
             val remoteName = UUID.randomUUID().toString()
             store.pushDatabase(remoteName, db, null)
@@ -47,7 +47,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
             store.databaseExists(remoteName) shouldBe true
 
             val resultingDatabase = store.fetchDatabase(remoteName).database
-            resultingDatabase.filePath shouldBe "$SYNC_DIR/original/Databases"
+            resultingDatabase.dbName shouldBe "DartsOther"
 
             val copiedFile = File("$SYNC_DIR/original/Databases/Test.txt")
             copiedFile.shouldExist()
@@ -71,7 +71,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
 
         val s3Client = AwsUtils.makeS3Client()
 
-        usingInMemoryDatabase(filePath = "$SYNC_DIR/Databases", withSchema = true) { db ->
+        usingInMemoryDatabase(withSchema = true) { db ->
             val store = AmazonS3RemoteDatabaseStore("dartzee-unit-test")
             val remoteName = UUID.randomUUID().toString()
             store.pushDatabase(remoteName, db, null)
@@ -87,7 +87,7 @@ class AmazonS3RemoteDatabaseStoreTest: AbstractTest()
     {
         Assume.assumeNotNull(AwsUtils.readCredentials("aws-sync"))
 
-        usingInMemoryDatabase(filePath = "$SYNC_DIR/Databases", withSchema = true) { db ->
+        usingInMemoryDatabase(withSchema = true) { db ->
             val store = AmazonS3RemoteDatabaseStore("dartzee-unit-test")
             val remoteName = UUID.randomUUID().toString()
             store.pushDatabase(remoteName, db, null)


### PR DESCRIPTION
https://trello.com/c/SNtbdHxw/26-db-sync-part-2

When using embedded derby, you set a `derby.system.home` prop - all databases you subsequently try to connect to must live here. I had completely forgotten about this, not least because the code that did this was in an entirely inappropriate place! This meant some assumptions about how the sync would work with regards to moving files around were wrong.

This PR refactors things so that they work correctly. The new flow is:

### Push
```
Dartabases/
├─ Darts/
│  ├─ <contents>
```
Take the *contents*, zip them up and push to S3.

### Pull

Retrieve the zip and place in temp sync directory. Then unzip directly to 'DartsOther':
```
Dartabases/
├─ Darts/
│  ├─ <contents>
├─ DartsOther/
│  ├─ <remote contents>
```
Swap in DartsOther -> Darts at the end