### PR TITLE
Test optimizations

### DIFF
--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -140,10 +140,7 @@ object DartsDatabaseUtil {
         //Now switch it in
         try
         {
-            mainDatabase.closeConnections()
             mainDatabase.shutDown()
-
-            otherDatabase.closeConnections()
             otherDatabase.shutDown()
 
             val error = FileUtil.swapInFile(mainDatabase.getDirectoryStr(), otherDatabase.getDirectoryStr())

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -31,6 +31,8 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
     private val connectionPoolLock = Any()
     private var connectionCreateCount = 0
 
+    var connectionsBorrowed = 0
+
     fun initialiseConnectionPool(initialCount: Int)
     {
         synchronized(connectionPoolLock)
@@ -48,6 +50,8 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
     {
         synchronized(connectionPoolLock)
         {
+            connectionsBorrowed++
+
             if (hsConnections.isEmpty())
             {
                 return createDatabaseConnection()

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -31,8 +31,6 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
     private val connectionPoolLock = Any()
     private var connectionCreateCount = 0
 
-    var connectionsBorrowed = 0
-
     fun initialiseConnectionPool(initialCount: Int)
     {
         synchronized(connectionPoolLock)
@@ -50,8 +48,6 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
     {
         synchronized(connectionPoolLock)
         {
-            connectionsBorrowed++
-
             if (hsConnections.isEmpty())
             {
                 return createDatabaseConnection()

--- a/src/main/kotlin/dartzee/utils/Database.kt
+++ b/src/main/kotlin/dartzee/utils/Database.kt
@@ -297,6 +297,7 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
 
     fun shutDown(): Boolean
     {
+        closeConnections()
         val command = "${getQualifiedDbName()};shutdown=true"
 
         try
@@ -311,13 +312,16 @@ class Database(val dbName: String = DartsDatabaseUtil.DATABASE_NAME, private val
                 return true
             }
 
-            logger.logSqlException(command, command, sqle)
+            if (!msg.contains("not found"))
+            {
+                logger.logSqlException(command, command, sqle)
+            }
         }
 
         return false
     }
 
-    fun closeConnections()
+    private fun closeConnections()
     {
         hsConnections.forEach { it.close() }
         hsConnections.clear()

--- a/src/test/kotlin/dartzee/achievements/TestDummyAchievementTotal.kt
+++ b/src/test/kotlin/dartzee/achievements/TestDummyAchievementTotal.kt
@@ -2,7 +2,6 @@ package dartzee.achievements
 
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertAchievement
-import dartzee.helper.wipeTable
 import io.kotlintest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotlintest.matchers.numerics.shouldBeLessThan
 import io.kotlintest.shouldBe
@@ -22,8 +21,6 @@ class TestDummyAchievementTotal: AbstractTest()
     @Test
     fun `Should retrieve all rows regardless of achievement reference`()
     {
-        wipeTable("Achievement")
-
         val a1 = insertAchievement(type = AchievementType.X01_BTBF)
         val a2 = insertAchievement(type = AchievementType.X01_SUCH_BAD_LUCK)
 

--- a/src/test/kotlin/dartzee/bean/TestPlayerTypeFilterPanel.kt
+++ b/src/test/kotlin/dartzee/bean/TestPlayerTypeFilterPanel.kt
@@ -3,7 +3,6 @@ package dartzee.bean
 import dartzee.db.PlayerEntity
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertPlayer
-import dartzee.helper.wipeTable
 import io.kotlintest.matchers.string.shouldBeEmpty
 import io.kotlintest.shouldBe
 import org.junit.Test
@@ -21,8 +20,6 @@ class TestPlayerTypeFilterPanel: AbstractTest()
     @Test
     fun `Should return correct filter SQL for humans and AIs`()
     {
-        wipeTable("Player")
-
         val ai = insertPlayer(strategy = "foo")
         val human = insertPlayer(strategy = "")
 

--- a/src/test/kotlin/dartzee/db/TestBulkInserter.kt
+++ b/src/test/kotlin/dartzee/db/TestBulkInserter.kt
@@ -41,8 +41,6 @@ class TestBulkInserter: AbstractTest()
     @Test
     fun `Should stack trace and do nothing if any entities are retrievedFromDb`()
     {
-        wipeTable("Player")
-
         val playerOne = PlayerEntity()
         val playerTwo = insertPlayer()
 
@@ -56,8 +54,6 @@ class TestBulkInserter: AbstractTest()
     @Test
     fun `Should log SQLExceptions if something goes wrong inserting entities`()
     {
-        wipeTable("Player")
-
         val playerOne = factoryPlayer("Pete")
         val playerTwo = factoryPlayer("Leah")
 

--- a/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartsMatchEntity.kt
@@ -26,8 +26,6 @@ class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
     @Test
     fun `LocalId field should be unique`()
     {
-        wipeTable("DartsMatch")
-
         insertDartsMatch(localId = 5)
         verifyNoLogs(CODE_SQL_EXCEPTION)
 
@@ -44,8 +42,6 @@ class TestDartsMatchEntity: AbstractEntityTest<DartsMatchEntity>()
     @Test
     fun `LocalIds should be assigned along with RowId`()
     {
-        wipeTable("DartsMatch")
-
         val entity = DartsMatchEntity()
         entity.assignRowId()
 

--- a/src/test/kotlin/dartzee/db/TestGameEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestGameEntity.kt
@@ -25,8 +25,6 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
     @Test
     fun `LocalId field should be unique`()
     {
-        wipeTable("Game")
-
         insertGame(localId = 5)
         verifyNoLogs(CODE_SQL_EXCEPTION)
 
@@ -43,8 +41,6 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
     @Test
     fun `LocalIds should be assigned along with RowId`()
     {
-        wipeTable("Game")
-
         val entity = GameEntity()
         entity.assignRowId()
 
@@ -65,9 +61,6 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
     @Test
     fun `Should get the participant count based on its own row ID`()
     {
-        wipeTable("Participant")
-        wipeTable("Game")
-
         val game = GameEntity()
         val gameId = game.assignRowId()
         game.saveToDatabase()
@@ -83,9 +76,6 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
     @Test
     fun `Should handle no participants when getting players vector`()
     {
-        wipeTable("Participant")
-        wipeTable("Game")
-
         val game = GameEntity()
         game.saveToDatabase()
 
@@ -95,10 +85,6 @@ class TestGameEntity: AbstractEntityTest<GameEntity>()
     @Test
     fun `Should return the player vector correctly`()
     {
-        wipeTable("Player")
-        wipeTable("Participant")
-        wipeTable("Game")
-
         //Insert a random player
         val game = GameEntity()
         val gameId = game.assignRowId()

--- a/src/test/kotlin/dartzee/db/TestLocalIdGenerator.kt
+++ b/src/test/kotlin/dartzee/db/TestLocalIdGenerator.kt
@@ -2,7 +2,6 @@ package dartzee.db
 
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertGame
-import dartzee.helper.wipeTable
 import dartzee.utils.InjectedThings.mainDatabase
 import io.kotlintest.matchers.collections.shouldBeUnique
 import io.kotlintest.matchers.collections.shouldHaveSize
@@ -14,16 +13,12 @@ class TestLocalIdGenerator: AbstractTest()
     @Test
     fun `It should generate an ID of 1 for an empty table`()
     {
-        wipeTable("Game")
-
         LocalIdGenerator(mainDatabase).generateLocalId("Game") shouldBe 1
     }
 
     @Test
     fun `It should generate the next ID for a non-empty table`()
     {
-        wipeTable("Game")
-
         insertGame(localId = 5)
 
         LocalIdGenerator(mainDatabase).generateLocalId("Game") shouldBe 6

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -84,10 +84,10 @@ abstract class AbstractTest
 
         mainDatabase.localIdGenerator.hmLastAssignedIdByTableName.clear()
 
-        if (mainDatabase.connectionsBorrowed > 0)
+        if (logDestination.haveRunInsert)
         {
             DartsDatabaseUtil.getAllEntitiesIncludingVersion().forEach { wipeTable(it.getTableName()) }
-            mainDatabase.connectionsBorrowed = 0
+            logDestination.haveRunInsert = false
         }
 
         InjectedThings.dartzeeCalculator = FakeDartzeeCalculator()

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -83,7 +83,13 @@ abstract class AbstractTest
         clearAllMocks()
 
         mainDatabase.localIdGenerator.hmLastAssignedIdByTableName.clear()
-        DartsDatabaseUtil.getAllEntitiesIncludingVersion().forEach { wipeTable(it.getTableName()) }
+
+        if (mainDatabase.connectionsBorrowed > 0)
+        {
+            DartsDatabaseUtil.getAllEntitiesIncludingVersion().forEach { wipeTable(it.getTableName()) }
+            mainDatabase.connectionsBorrowed = 0
+        }
+
         InjectedThings.dartzeeCalculator = FakeDartzeeCalculator()
 
         //Clear cached dartboards

--- a/src/test/kotlin/dartzee/helper/FakeLogDestination.kt
+++ b/src/test/kotlin/dartzee/helper/FakeLogDestination.kt
@@ -1,15 +1,22 @@
 package dartzee.helper
 
+import dartzee.logging.CODE_SQL
 import dartzee.logging.ILogDestination
 import dartzee.logging.LogRecord
 
 class FakeLogDestination: ILogDestination
 {
     val logRecords: MutableList<LogRecord> = mutableListOf()
+    var haveRunInsert = false
 
     override fun log(record: LogRecord)
     {
         logRecords.add(record)
+
+        if (record.loggingCode == CODE_SQL && record.message.contains("INSERT"))
+        {
+            haveRunInsert = true
+        }
     }
 
     override fun contextUpdated(context: Map<String, Any?>) {}

--- a/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
+++ b/src/test/kotlin/dartzee/helper/InMemoryDatabaseHelper.kt
@@ -348,7 +348,6 @@ fun usingInMemoryDatabase(dbName: String = UUID.randomUUID().toString(),
 
 fun Database.closeConnectionsAndDrop(dbName: String)
 {
-    closeConnections()
     shutDown()
 
     try


### PR DESCRIPTION
Some optimizations that came out of running a YourKit profile on the full test suite:

 - New strat for testing that SQL doesn't hit the mainDatabase, which doesn't require nesting `useInMemoryDatabase`
 - Only wipe tables between tests if necessary (track if SQL was run by the previous test)

This branch is OOMing in actions too, though... sigh. Need to get JVisualVm out next I guess.