### PR TITLE
Dartboard leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,14 @@ compileTestKotlin {
     }
 }
 
+test {
+    jvmArgs '-Dcom.sun.management.jmxremote',
+            '-Dcom.sun.management.jmxremote.port=9010',
+            '-Dcom.sun.management.jmxremote.authenticate=false',
+            '-Dcom.sun.management.jmxremote.ssl=false',
+            '-Djava.rmi.server.hostname=localhost'
+}
+
 task runDev(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,12 @@ task runDev(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 
     args 'devMode', 'trueLaunch'
+    jvmArgs '-Dcom.sun.management.jmxremote',
+            '-Dcom.sun.management.jmxremote.port=9010',
+            '-Dcom.sun.management.jmxremote.authenticate=false',
+            '-Dcom.sun.management.jmxremote.ssl=false',
+            '-Djava.rmi.server.hostname=localhost'
+
     main 'dartzee.main.DartsMainKt'
 }
 

--- a/src/main/kotlin/dartzee/ai/DartsAiModel.kt
+++ b/src/main/kotlin/dartzee/ai/DartsAiModel.kt
@@ -237,11 +237,11 @@ data class DartsAiModel(val standardDeviation: Double,
     }
 
     private fun getDistributionToUse(pt: Point, dartboard: Dartboard) =
-        if (dartboard.isDouble(pt) && standardDeviationDoubles != null) NormalDistribution(mean.toDouble(), standardDeviationDoubles) else distribution
+        if (standardDeviationDoubles != null && dartboard.isDouble(pt)) NormalDistribution(mean.toDouble(), standardDeviationDoubles) else distribution
 
     private fun generateAngle(pt: Point, dartboard: Dartboard): Double
     {
-        if (dartboard.isDouble(pt) || standardDeviationCentral == null)
+        if (standardDeviationCentral == null || dartboard.isDouble(pt))
         {
             //Just pluck a number from 0-360.
             return generateRandomAngle()

--- a/src/main/kotlin/dartzee/object/DartboardSegment.kt
+++ b/src/main/kotlin/dartzee/object/DartboardSegment.kt
@@ -56,6 +56,9 @@ data class DartboardSegment(val type: SegmentType, val score: Int)
         val xMins: List<Point> = hmYCoordToPoints.values.map { points -> points.minBy { it.x }!! }
         val xMaxes: List<Point> = hmYCoordToPoints.values.map { points -> points.maxBy { it.x }!! }
         edgePoints.addAll(yMins + yMaxes + xMins + xMaxes)
+
+        hmXCoordToPoints.clear()
+        hmYCoordToPoints.clear()
     }
 
     fun getRoughProbability(): Double {

--- a/src/main/kotlin/dartzee/object/DartboardSegment.kt
+++ b/src/main/kotlin/dartzee/object/DartboardSegment.kt
@@ -1,5 +1,6 @@
 package dartzee.`object`
 
+import dartzee.core.obj.HashMapList
 import dartzee.core.util.getAttributeInt
 import dartzee.core.util.setAttributeAny
 import dartzee.utils.getColourForPointAndSegment
@@ -18,8 +19,8 @@ data class DartboardSegment(val type: SegmentType, val score: Int)
     val edgePoints = mutableSetOf<Point>()
 
     //For tracking edge points
-    private val hmXCoordToPoints = mutableMapOf<Int, Set<Point>>()
-    private val hmYCoordToPoints = mutableMapOf<Int, Set<Point>>()
+    private val hmXCoordToPoints = HashMapList<Int, Point>()
+    private val hmYCoordToPoints = HashMapList<Int, Point>()
 
     /**
      * Helpers
@@ -33,11 +34,8 @@ data class DartboardSegment(val type: SegmentType, val score: Int)
     {
         points.add(pt)
 
-        val xSet = hmXCoordToPoints.getOrDefault(pt.x, emptySet())
-        hmXCoordToPoints[pt.x] = xSet + pt
-
-        val ySet = hmYCoordToPoints.getOrDefault(pt.y, emptySet())
-        hmYCoordToPoints[pt.y] = ySet + pt
+        hmXCoordToPoints.putInList(pt.x, pt)
+        hmYCoordToPoints.putInList(pt.y, pt)
     }
 
     fun getColorMap(colourWrapper: ColourWrapper?) = points.map { pt -> pt to getColourForPointAndSegment(pt, this, colourWrapper) }

--- a/src/main/kotlin/dartzee/object/DartboardSegment.kt
+++ b/src/main/kotlin/dartzee/object/DartboardSegment.kt
@@ -3,6 +3,7 @@ package dartzee.`object`
 import dartzee.core.obj.HashMapList
 import dartzee.core.util.getAttributeInt
 import dartzee.core.util.setAttributeAny
+import dartzee.utils.getColourForPointAndSegment
 import org.w3c.dom.Element
 import java.awt.Point
 
@@ -36,6 +37,9 @@ data class DartboardSegment(val type: SegmentType, val score: Int)
         hmXCoordToPoints.putInList(pt.x, pt)
         hmYCoordToPoints.putInList(pt.y, pt)
     }
+
+    fun getColorMap(colourWrapper: ColourWrapper?) = points.map { pt -> pt to getColourForPointAndSegment(pt, this, colourWrapper) }
+    fun containsPoint(point: Point) = points.contains(point)
 
     override fun toString() = "$score ($type)"
 

--- a/src/main/kotlin/dartzee/screen/Dartboard.kt
+++ b/src/main/kotlin/dartzee/screen/Dartboard.kt
@@ -100,6 +100,7 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
 
         //Construct the segments, populated with their points. Cache pt -> segment.
         getPointList(width, height).forEach { factoryAndCacheSegmentForPoint(it) }
+        getAllSegments().forEach { it.computeEdgePoints() }
 
         if (usingCache)
         {
@@ -264,9 +265,8 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
     {
         val pointsForCurrentSegment = segment.points
         val edgeColour = getEdgeColourForSegment(segment)
-        for (i in pointsForCurrentSegment.indices)
+        for (pt in pointsForCurrentSegment)
         {
-            val pt = pointsForCurrentSegment[i]
             if (edgeColour != null && segment.isEdgePoint(pt))
             {
                 colourPoint(pt, edgeColour)
@@ -328,11 +328,11 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
     /**
      * Public methods
      */
-    fun getPointsForSegment(score: Int, type: SegmentType): MutableList<Point>
+    fun getPointsForSegment(score: Int, type: SegmentType): Set<Point>
     {
         val segmentKey = score.toString() + "_" + type
         val segment = hmSegmentKeyToSegment[segmentKey]
-        return segment?.points ?: mutableListOf()
+        return segment?.points ?: setOf()
     }
     fun getSegment(score: Int, type: SegmentType): DartboardSegment? = hmSegmentKeyToSegment["${score}_$type"]
 

--- a/src/main/kotlin/dartzee/screen/Dartboard.kt
+++ b/src/main/kotlin/dartzee/screen/Dartboard.kt
@@ -100,7 +100,11 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
 
         //Construct the segments, populated with their points. Cache pt -> segment.
         getPointList(width, height).forEach { factoryAndCacheSegmentForPoint(it) }
-        getAllSegments().forEach { it.computeEdgePoints() }
+
+        if (colourWrapper?.edgeColour != null)
+        {
+            getAllSegments().forEach { it.computeEdgePoints() }
+        }
 
         if (usingCache)
         {

--- a/src/main/kotlin/dartzee/screen/Dartboard.kt
+++ b/src/main/kotlin/dartzee/screen/Dartboard.kt
@@ -62,7 +62,6 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
 
     var dartboardImage: BufferedImage? = null
     val dartboardLabel = JLabel()
-     //You know what this is...
 
     init
     {
@@ -100,11 +99,7 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
 
         //Construct the segments, populated with their points. Cache pt -> segment.
         getPointList(width, height).forEach { factoryAndCacheSegmentForPoint(it) }
-
-        if (colourWrapper?.edgeColour != null)
-        {
-            getAllSegments().forEach { it.computeEdgePoints() }
-        }
+        getAllSegments().forEach { it.computeEdgePoints() }
 
         if (usingCache)
         {

--- a/src/main/kotlin/dartzee/screen/Dartboard.kt
+++ b/src/main/kotlin/dartzee/screen/Dartboard.kt
@@ -35,8 +35,7 @@ const val LAYER_SLIDER = 4
 
 open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), MouseListener, MouseMotionListener
 {
-    private var hmPointToSegment = mutableMapOf<Point, DartboardSegment>()
-    protected var hmSegmentKeyToSegment = mutableMapOf<String, DartboardSegment>()
+    protected val hmSegmentKeyToSegment = mutableMapOf<String, DartboardSegment>()
 
     private val dartLabels = mutableListOf<JLabel>()
 
@@ -98,7 +97,9 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
         this.colourWrapper = colourWrapper
         centerPoint = Point(width / 2, height / 2)
         diameter = 0.7 * width
-        hmPointToSegment.clear()
+
+        //Construct the segments, populated with their points. Cache pt -> segment.
+        getPointList(width, height).forEach { factoryAndCacheSegmentForPoint(it) }
 
         if (usingCache)
         {
@@ -106,13 +107,7 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
         }
         else
         {
-            dartboardImage = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-
-            //Construct the segments, populated with their points. Cache pt -> segment.
-            getPointList(width, height).forEach { factoryAndCacheSegmentForPoint(it) }
-
-            //Render the actual image
-            dartboardImage?.paint { getColourForPointAndSegment(it, getSegmentForPoint(it), colourWrapper) }
+            paintDartboardImage()
         }
 
         addScoreLabels()
@@ -137,10 +132,16 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
         }
     }
 
-    open fun initialiseFromTemplate()
+    private fun paintDartboardImage()
     {
-        hmPointToSegment = dartboardTemplate!!.getPointToSegmentMap()
-        hmSegmentKeyToSegment = dartboardTemplate!!.getSegmentKeyToSegmentMap()
+        val hmPointToColor = getAllSegments().flatMap { it.getColorMap(colourWrapper) }.toMap()
+
+        dartboardImage = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        dartboardImage?.paint { hmPointToColor[it] }
+    }
+
+    fun initialiseFromTemplate()
+    {
         dartboardImage = dartboardTemplate!!.getDartboardImg()
     }
 
@@ -299,7 +300,7 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
 
     fun getSegmentForPoint(pt: Point, stackTrace: Boolean = true): DartboardSegment
     {
-        val segment = hmPointToSegment[pt]
+        val segment = getAllSegments().firstOrNull { it.containsPoint(pt) }
         if (segment != null)
         {
             return segment
@@ -321,7 +322,6 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
 
         val segment = hmSegmentKeyToSegment.getOrPut(segmentKey) { newSegment }
         segment.addPoint(pt)
-        hmPointToSegment[pt] = segment
         return segment
     }
 
@@ -510,18 +510,6 @@ open class Dartboard(width: Int = 400, height: Int = 400): JLayeredPane(), Mouse
     inner class DartboardTemplate(dartboard: Dartboard)
     {
         private val dartboardImg = dartboard.dartboardImage!!
-        private val hmPointToSegment = dartboard.hmPointToSegment
-        private val hmSegmentKeyToSegment = dartboard.hmSegmentKeyToSegment
-
-        fun getPointToSegmentMap(): MutableMap<Point, DartboardSegment>
-        {
-            return hmPointToSegment.toMutableMap()
-        }
-
-        fun getSegmentKeyToSegmentMap(): MutableMap<String, DartboardSegment>
-        {
-            return hmSegmentKeyToSegment.toMutableMap()
-        }
 
         fun getDartboardImg(): BufferedImage
         {

--- a/src/main/kotlin/dartzee/screen/MenuScreen.kt
+++ b/src/main/kotlin/dartzee/screen/MenuScreen.kt
@@ -7,6 +7,8 @@ import dartzee.screen.preference.PreferencesScreen
 import dartzee.screen.reporting.ReportingSetupScreen
 import dartzee.screen.stats.overall.LeaderboardsScreen
 import dartzee.screen.sync.SyncManagementScreen
+import dartzee.screen.sync.SyncSummaryPanel
+import dartzee.sync.SyncSummary
 import dartzee.utils.ResourceCache
 import java.awt.BorderLayout
 import java.awt.Font
@@ -25,7 +27,7 @@ class MenuScreen : EmbeddedScreen()
     private val btnAbout = JButton("About...")
     private val btnDartzeeTemplates = JButton("Dartzee")
     private val btnUtilities = JButton("Utilities")
-    private val syncSummary = ScreenCache.syncSummaryPanel
+    private val btnSyncSummary = SyncSummaryPanel()
     private val btnGameReport = JButton("Game Report")
 
     private val buttonFont = ResourceCache.BASE_FONT.deriveFont(Font.PLAIN, 18f)
@@ -57,8 +59,8 @@ class MenuScreen : EmbeddedScreen()
         btnUtilities.font = buttonFont
         btnUtilities.setBounds(590, 340, 150, 50)
         panel.add(btnUtilities)
-        syncSummary.setBounds(200, 465, 400, 125)
-        panel.add(syncSummary)
+        btnSyncSummary.setBounds(200, 465, 400, 125)
+        panel.add(btnSyncSummary)
         btnGameReport.font = buttonFont
         btnGameReport.setBounds(60, 340, 150, 50)
         panel.add(btnGameReport)
@@ -69,6 +71,11 @@ class MenuScreen : EmbeddedScreen()
 
         //Add ActionListeners
         addActionListenerToAllChildren(this)
+    }
+
+    fun refreshSummary(syncSummary: SyncSummary)
+    {
+        btnSyncSummary.refreshSummary(syncSummary)
     }
 
     override fun getScreenName() = "Menu"
@@ -92,7 +99,7 @@ class MenuScreen : EmbeddedScreen()
             }
 
             btnPreferences -> ScreenCache.switch<PreferencesScreen>()
-            syncSummary -> ScreenCache.switch<SyncManagementScreen>()
+            btnSyncSummary -> ScreenCache.switch<SyncManagementScreen>()
             btnNewGame -> ScreenCache.switch<GameSetupScreen>()
             btnManagePlayers -> ScreenCache.switch<PlayerManagementScreen>()
             btnGameReport -> ScreenCache.switch<ReportingSetupScreen>()

--- a/src/main/kotlin/dartzee/screen/MenuScreen.kt
+++ b/src/main/kotlin/dartzee/screen/MenuScreen.kt
@@ -9,17 +9,18 @@ import dartzee.screen.stats.overall.LeaderboardsScreen
 import dartzee.screen.sync.SyncManagementScreen
 import dartzee.screen.sync.SyncSummaryPanel
 import dartzee.sync.SyncSummary
+import dartzee.utils.InjectedThings.dartboardSize
 import dartzee.utils.ResourceCache
 import java.awt.BorderLayout
 import java.awt.Font
 import java.awt.event.ActionEvent
+import javax.swing.ImageIcon
 import javax.swing.JButton
+import javax.swing.JLabel
 import javax.swing.JPanel
 
 class MenuScreen : EmbeddedScreen()
 {
-    private val menuDartboard = Dartboard(400, 400)
-
     private val btnNewGame = JButton("New Game")
     private val btnManagePlayers = JButton("Manage Players")
     private val btnLeaderboards = JButton("Leaderboards")
@@ -64,13 +65,21 @@ class MenuScreen : EmbeddedScreen()
         btnGameReport.font = buttonFont
         btnGameReport.setBounds(60, 340, 150, 50)
         panel.add(btnGameReport)
-
-        menuDartboard.setBounds(200, 65, 400, 400)
-        menuDartboard.paintDartboard(null, false)
-        panel.add(menuDartboard)
+        panel.add(renderDartboard())
 
         //Add ActionListeners
         addActionListenerToAllChildren(this)
+    }
+
+    private fun renderDartboard(): JLabel
+    {
+        val board = Dartboard(dartboardSize, dartboardSize)
+        board.paintDartboard(null, false)
+
+        val img = ImageIcon(board.dartboardImage!!)
+        val lbl = JLabel(img)
+        lbl.setBounds(200, 65, dartboardSize, dartboardSize)
+        return lbl
     }
 
     fun refreshSummary(syncSummary: SyncSummary)

--- a/src/main/kotlin/dartzee/screen/dartzee/DartzeeRuleVerificationPanel.kt
+++ b/src/main/kotlin/dartzee/screen/dartzee/DartzeeRuleVerificationPanel.kt
@@ -5,10 +5,9 @@ import dartzee.core.util.setFontSize
 import dartzee.dartzee.DartzeeRuleCalculationResult
 import dartzee.dartzee.DartzeeRuleDto
 import dartzee.listener.DartboardListener
-import dartzee.screen.game.dartzee.SegmentStatus
 import dartzee.utils.DartsColour
 import dartzee.utils.InjectedThings.dartzeeCalculator
-import dartzee.utils.InjectedThings.verificationDartboardSize
+import dartzee.utils.InjectedThings.dartboardSize
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
@@ -20,7 +19,7 @@ import javax.swing.border.EmptyBorder
 
 class DartzeeRuleVerificationPanel: JPanel(), DartboardListener, ActionListener
 {
-    val dartboard = DartzeeDartboard(verificationDartboardSize, verificationDartboardSize)
+    val dartboard = DartzeeDartboard(dartboardSize, dartboardSize)
     val dartsThrown = mutableListOf<Dart>()
     private var dartzeeRule = DartzeeRuleDto(null, null, null, null, false, false)
 

--- a/src/main/kotlin/dartzee/sync/SyncUtils.kt
+++ b/src/main/kotlin/dartzee/sync/SyncUtils.kt
@@ -3,6 +3,7 @@ package dartzee.sync
 import dartzee.core.util.formatTimestamp
 import dartzee.db.GameEntity
 import dartzee.db.SyncAuditEntity
+import dartzee.screen.MenuScreen
 import dartzee.screen.ScreenCache
 import dartzee.utils.InjectedThings.mainDatabase
 import dartzee.utils.PREFERENCES_STRING_REMOTE_DATABASE_NAME
@@ -45,7 +46,7 @@ fun refreshSyncSummary()
             SyncSummary(remoteName, lastSyncDesc, "$pendingGameCount")
         }
 
-        ScreenCache.syncSummaryPanel.refreshSummary(syncSummary)
+        ScreenCache.get<MenuScreen>().refreshSummary(syncSummary)
     }
 }
 

--- a/src/main/kotlin/dartzee/utils/GeometryUtil.kt
+++ b/src/main/kotlin/dartzee/utils/GeometryUtil.kt
@@ -116,7 +116,7 @@ private fun getQuadrant(xIsPositive: Boolean, yIsPositive: Boolean): Quadrant?
 /**
  * For a group of points, calculate the average point
  */
-fun getAverage(points: List<Point>): Point
+fun getAverage(points: Set<Point>): Point
 {
     val xAvg = points.map{ it.x }.average()
     val yAvg = points.map{ it.y }.average()

--- a/src/main/kotlin/dartzee/utils/InjectedThings.kt
+++ b/src/main/kotlin/dartzee/utils/InjectedThings.kt
@@ -22,7 +22,7 @@ object InjectedThings
     var databaseDirectory = DATABASE_FILE_PATH
     var mainDatabase: Database = Database()
     var dartzeeCalculator: AbstractDartzeeCalculator = DartzeeCalculator()
-    var verificationDartboardSize = 400
+    var dartboardSize = 400
     var preferencesDartboardSize = 450
     var dartzeeRuleFactory: AbstractDartzeeRuleFactory = DartzeeRuleFactory()
     var dartzeeTemplateFactory: AbstractDartzeeTemplateFactory = DartzeeTemplateFactory()

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -60,7 +60,7 @@ abstract class AbstractTest
 
         InjectedThings.databaseDirectory = TEST_DB_DIRECTORY
         InjectedThings.logger = logger
-        InjectedThings.verificationDartboardSize = 50
+        InjectedThings.dartboardSize = 50
         InjectedThings.preferencesDartboardSize = 50
         InjectedThings.clock = Clock.fixed(CURRENT_TIME, ZoneId.of("UTC"))
 

--- a/src/test/kotlin/dartzee/helper/SyncAssertions.kt
+++ b/src/test/kotlin/dartzee/helper/SyncAssertions.kt
@@ -1,7 +1,7 @@
 package dartzee.helper
 
+import dartzee.screen.MenuScreen
 import dartzee.screen.ScreenCache
-import dartzee.screen.sync.SyncSummaryPanel
 import dartzee.sync.SYNC_DIR
 import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.InjectedThings.mainDatabase
@@ -14,22 +14,14 @@ const val REMOTE_NAME = "Goomba"
 
 fun shouldUpdateSyncSummary(testFn: () -> Unit)
 {
-    val originalPanel = ScreenCache.syncSummaryPanel
+    val menuScreen = mockk<MenuScreen>(relaxed = true)
+    ScreenCache.hmClassToScreen[MenuScreen::class.java] = menuScreen
 
-    try
-    {
-        mainDatabase.updateDatabaseVersion(DartsDatabaseUtil.DATABASE_VERSION)
-        val summaryPanelMock = mockk<SyncSummaryPanel>(relaxed = true)
-        ScreenCache.syncSummaryPanel = summaryPanelMock
+    mainDatabase.updateDatabaseVersion(DartsDatabaseUtil.DATABASE_VERSION)
 
-        testFn()
+    testFn()
 
-        verify { summaryPanelMock.refreshSummary(any()) }
-    }
-    finally
-    {
-        ScreenCache.syncSummaryPanel = originalPanel
-    }
+    verify { menuScreen.refreshSummary(any()) }
 }
 
 fun syncDirectoryShouldNotExist()

--- a/src/test/kotlin/dartzee/object/TestDartboardSegment.kt
+++ b/src/test/kotlin/dartzee/object/TestDartboardSegment.kt
@@ -56,7 +56,7 @@ class TestDartboardSegment: AbstractTest()
         val points = listOf(Point(1, 0), Point(0, 1), Point(20, -5))
         points.forEach { segment.addPoint(it) }
 
-        segment.points shouldBe points.toMutableList()
+        segment.points shouldBe points.toMutableSet()
     }
 
 
@@ -76,6 +76,7 @@ class TestDartboardSegment: AbstractTest()
 
         val pts = xRange.map { x -> yRange.map { y -> Point(x, y) } }.flatten()
         pts.forEach { segment.addPoint(it) }
+        segment.computeEdgePoints()
 
         //Corners
         segment.isEdgePoint(Point(0, 0)) shouldBe true
@@ -120,8 +121,8 @@ class TestDartboardSegment: AbstractTest()
         val yRange = 0..4
 
         val pts = xRange.map { x -> yRange.filter{ it <= x }.map { y -> Point(x, y) } }.flatten()
-
         pts.forEach { segment.addPoint(it) }
+        segment.computeEdgePoints()
 
         //Bottom edge
         segment.isEdgePoint(Point(0, 0)) shouldBe true

--- a/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
+++ b/src/test/kotlin/dartzee/screen/game/TestGamePanelDartzee.kt
@@ -37,8 +37,8 @@ class TestGamePanelDartzee: AbstractTest()
     @Test
     fun `Should initialise totalRounds based on the number of rules`()
     {
-        makeGamePanel(listOf(makeDartzeeRuleDto())).totalRounds shouldBe 2
-        makeGamePanel(listOf(makeDartzeeRuleDto(), makeDartzeeRuleDto())).totalRounds shouldBe 3
+        withGamePanel(listOf(makeDartzeeRuleDto())) { it.totalRounds shouldBe 2 }
+        withGamePanel(listOf(makeDartzeeRuleDto(), makeDartzeeRuleDto())) { it.totalRounds shouldBe 3 }
     }
 
     @Test
@@ -47,8 +47,7 @@ class TestGamePanelDartzee: AbstractTest()
         val carousel = DartzeeRuleCarousel(rules)
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
 
-        val gamePanel = makeGamePanel(rules, summaryPanel)
-        carousel.listener shouldBe gamePanel
+        withGamePanel(rules, summaryPanel) { carousel.listener shouldBe it }
     }
 
     @Test
@@ -58,11 +57,12 @@ class TestGamePanelDartzee: AbstractTest()
 
         val summaryPanel = mockk<DartzeeRuleSummaryPanel>(relaxed = true)
 
-        val gamePanel = makeGamePanel(rules, summaryPanel, game)
-        gamePanel.loadGame()
+        withGamePanel(rules, summaryPanel, game) { gamePanel ->
+            gamePanel.loadGame()
 
-        verify { summaryPanel.gameFinished() }
-        gamePanel.currentPlayerNumber shouldBe 0
+            verify { summaryPanel.gameFinished() }
+            gamePanel.currentPlayerNumber shouldBe 0
+        }
     }
 
     @Test
@@ -72,19 +72,20 @@ class TestGamePanelDartzee: AbstractTest()
         val carousel = DartzeeRuleCarousel(rules)
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
 
-        val gamePanel = makeGamePanel(rules, summaryPanel, game)
-        gamePanel.loadGame()
+        withGamePanel(rules, summaryPanel, game) { gamePanel ->
+            gamePanel.loadGame()
 
-        gamePanel.getPlayerState().getScoreSoFar() shouldBe 115
+            gamePanel.getPlayerState().getScoreSoFar() shouldBe 115
 
-        val tiles = carousel.completeTiles
-        tiles[0].dto shouldBe innerOuterInner
-        tiles[0].ruleNumber shouldBe 2
-        tiles[0].getScoreForHover() shouldBe 50
+            val tiles = carousel.completeTiles
+            tiles[0].dto shouldBe innerOuterInner
+            tiles[0].ruleNumber shouldBe 2
+            tiles[0].getScoreForHover() shouldBe 50
 
-        tiles[1].dto shouldBe twoBlackOneWhite
-        tiles[1].ruleNumber shouldBe 1
-        tiles[1].getScoreForHover() shouldBe -115
+            tiles[1].dto shouldBe twoBlackOneWhite
+            tiles[1].ruleNumber shouldBe 1
+            tiles[1].getScoreForHover() shouldBe -115
+        }
     }
 
     @Test
@@ -95,26 +96,28 @@ class TestGamePanelDartzee: AbstractTest()
         val game = setUpDartzeeGameOnDatabase(1)
         val carousel = DartzeeRuleCarousel(rules)
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
-        val panel = makeGamePanel(rules, summaryPanel, game)
-        panel.loadGame()
 
-        carousel.completeTiles.shouldBeEmpty()
-        carousel.pendingTiles.size shouldBe 2
+        withGamePanel(rules, summaryPanel, game) { panel ->
+            panel.loadGame()
 
-        val expectedSegments = getAllPossibleSegments().filter { !it.isMiss() && !it.isDoubleExcludingBull() }
-        panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactlyInAnyOrder(*expectedSegments.toTypedArray())
+            carousel.completeTiles.shouldBeEmpty()
+            carousel.pendingTiles.size shouldBe 2
 
-        panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
+            val expectedSegments = getAllPossibleSegments().filter { !it.isMiss() && !it.isDoubleExcludingBull() }
+            panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactlyInAnyOrder(*expectedSegments.toTypedArray())
 
-        val twoBlackOneWhiteSegments = twoBlackOneWhite.calculationResult!!.scoringSegments.toTypedArray()
-        panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactlyInAnyOrder(*twoBlackOneWhiteSegments)
+            panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
 
-        panel.dartThrown(makeDart(20, 0, SegmentType.MISS))
-        panel.dartboard.segmentStatus!!.scoringSegments.shouldBeEmpty()
+            val twoBlackOneWhiteSegments = twoBlackOneWhite.calculationResult!!.scoringSegments.toTypedArray()
+            panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactlyInAnyOrder(*twoBlackOneWhiteSegments)
 
-        panel.btnReset.isEnabled = true
-        panel.btnReset.doClick()
-        panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactlyInAnyOrder(*expectedSegments.toTypedArray())
+            panel.dartThrown(makeDart(20, 0, SegmentType.MISS))
+            panel.dartboard.segmentStatus!!.scoringSegments.shouldBeEmpty()
+
+            panel.btnReset.isEnabled = true
+            panel.btnReset.doClick()
+            panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactlyInAnyOrder(*expectedSegments.toTypedArray())
+        }
     }
 
     @Test
@@ -127,35 +130,37 @@ class TestGamePanelDartzee: AbstractTest()
 
         val carousel = DartzeeRuleCarousel(rules)
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
-        val panel = makeGamePanel(rules, summaryPanel, game)
-        panel.startNewGame(listOf(player))
 
-        panel.btnConfirm.isVisible shouldBe true
+        withGamePanel(rules, summaryPanel, game) { panel ->
+            panel.startNewGame(listOf(player))
 
-        panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
-        panel.dartThrown(makeDart(5, 1, SegmentType.OUTER_SINGLE))
-        panel.dartThrown(makeDart(1, 1, SegmentType.OUTER_SINGLE))
+            panel.btnConfirm.isVisible shouldBe true
 
-        panel.btnConfirm.doClick()
+            panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
+            panel.dartThrown(makeDart(5, 1, SegmentType.OUTER_SINGLE))
+            panel.dartThrown(makeDart(1, 1, SegmentType.OUTER_SINGLE))
 
-        panel.btnConfirm.isVisible shouldBe false
-        getCountFromTable("DartzeeRoundResult") shouldBe 0
-        panel.getPlayerState().getScoreSoFar() shouldBe 26
+            panel.btnConfirm.doClick()
 
-        panel.dartThrown(makeDart(20, 1, SegmentType.INNER_SINGLE))
-        panel.dartThrown(makeDart(5, 1, SegmentType.OUTER_SINGLE))
-        panel.dartThrown(makeDart(1, 1, SegmentType.INNER_SINGLE))
+            panel.btnConfirm.isVisible shouldBe false
+            getCountFromTable("DartzeeRoundResult") shouldBe 0
+            panel.getPlayerState().getScoreSoFar() shouldBe 26
 
-        carousel.getDisplayedTiles().first().doClick()
+            panel.dartThrown(makeDart(20, 1, SegmentType.INNER_SINGLE))
+            panel.dartThrown(makeDart(5, 1, SegmentType.OUTER_SINGLE))
+            panel.dartThrown(makeDart(1, 1, SegmentType.INNER_SINGLE))
 
-        panel.getPlayerState().getScoreSoFar() shouldBe 52
+            carousel.getDisplayedTiles().first().doClick()
 
-        val rr = DartzeeRoundResultEntity().retrieveEntities().first()
-        rr.score shouldBe 26
-        rr.roundNumber shouldBe 2
-        rr.playerId shouldBe player.rowId
-        rr.success shouldBe true
-        rr.ruleNumber shouldBe 2
+            panel.getPlayerState().getScoreSoFar() shouldBe 52
+
+            val rr = DartzeeRoundResultEntity().retrieveEntities().first()
+            rr.score shouldBe 26
+            rr.roundNumber shouldBe 2
+            rr.playerId shouldBe player.rowId
+            rr.success shouldBe true
+            rr.ruleNumber shouldBe 2
+        }
     }
 
     @Test
@@ -163,44 +168,47 @@ class TestGamePanelDartzee: AbstractTest()
     {
         val carousel = DartzeeRuleCarousel(rules)
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
-        val panel = makeGamePanel(rules, summaryPanel)
-        panel.startNewGame(listOf(insertPlayer(strategy = "")))
+        withGamePanel(rules, summaryPanel) { panel ->
+            panel.startNewGame(listOf(insertPlayer(strategy = "")))
 
-        panel.hoverChanged(SegmentStatus(listOf(doubleNineteen), listOf(doubleNineteen)))
-        panel.dartboard.segmentStatus shouldBe SegmentStatus(listOf(doubleNineteen), listOf(doubleNineteen))
+            panel.hoverChanged(SegmentStatus(listOf(doubleNineteen), listOf(doubleNineteen)))
+            panel.dartboard.segmentStatus shouldBe SegmentStatus(listOf(doubleNineteen), listOf(doubleNineteen))
 
-        panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
-        panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
+            panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
+            panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
 
-        panel.hoverChanged(SegmentStatus(listOf(doubleTwenty), listOf(doubleTwenty)))
-        panel.dartboard.segmentStatus shouldBe SegmentStatus(listOf(doubleTwenty), listOf(doubleTwenty))
+            panel.hoverChanged(SegmentStatus(listOf(doubleTwenty), listOf(doubleTwenty)))
+            panel.dartboard.segmentStatus shouldBe SegmentStatus(listOf(doubleTwenty), listOf(doubleTwenty))
 
-        panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
-        panel.dartboard.segmentStatus shouldBe SegmentStatus(getAllPossibleSegments(), getAllPossibleSegments())
-        panel.hoverChanged(SegmentStatus(listOf(bullseye), listOf(bullseye)))
-        panel.dartboard.segmentStatus shouldBe SegmentStatus(getAllPossibleSegments(), getAllPossibleSegments())
+            panel.dartThrown(makeDart(20, 1, SegmentType.OUTER_SINGLE))
+            panel.dartboard.segmentStatus shouldBe SegmentStatus(getAllPossibleSegments(), getAllPossibleSegments())
+            panel.hoverChanged(SegmentStatus(listOf(bullseye), listOf(bullseye)))
+            panel.dartboard.segmentStatus shouldBe SegmentStatus(getAllPossibleSegments(), getAllPossibleSegments())
+        }
     }
 
     @Test
     fun `Should select the right player when a scorer is selected`()
     {
         val summaryPanel = mockk<DartzeeRuleSummaryPanel>(relaxed = true)
-        val panel = makeGamePanel(rules, summaryPanel, totalPlayers = 2)
-        panel.startNewGame(listOf(insertPlayer(strategy = ""), insertPlayer(strategy = "")))
 
-        panel.scorerSelected(panel.scorersOrdered[0])
-        panel.currentPlayerNumber shouldBe 0
-        panel.scorersOrdered[0].lblName.foreground shouldBe Color.RED
-        panel.scorersOrdered[1].lblName.foreground shouldBe Color.BLACK
-        verify { summaryPanel.update(listOf(), listOf(), 0, 1) }
+        withGamePanel(rules, summaryPanel, totalPlayers = 2) { panel ->
+            panel.startNewGame(listOf(insertPlayer(strategy = ""), insertPlayer(strategy = "")))
 
-        clearAllMocks()
+            panel.scorerSelected(panel.scorersOrdered[0])
+            panel.currentPlayerNumber shouldBe 0
+            panel.scorersOrdered[0].lblName.foreground shouldBe Color.RED
+            panel.scorersOrdered[1].lblName.foreground shouldBe Color.BLACK
+            verify { summaryPanel.update(listOf(), listOf(), 0, 1) }
 
-        panel.scorerSelected(panel.scorersOrdered[1])
-        panel.currentPlayerNumber shouldBe 1
-        panel.scorersOrdered[0].lblName.foreground shouldBe Color.BLACK
-        panel.scorersOrdered[1].lblName.foreground shouldBe Color.RED
-        verify { summaryPanel.update(listOf(), listOf(), 0, 1) }
+            clearAllMocks()
+
+            panel.scorerSelected(panel.scorersOrdered[1])
+            panel.currentPlayerNumber shouldBe 1
+            panel.scorersOrdered[0].lblName.foreground shouldBe Color.BLACK
+            panel.scorersOrdered[1].lblName.foreground shouldBe Color.RED
+            verify { summaryPanel.update(listOf(), listOf(), 0, 1) }
+        }
     }
 
     @Test
@@ -213,15 +221,17 @@ class TestGamePanelDartzee: AbstractTest()
 
         val carousel = DartzeeRuleCarousel(rules)
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
-        val panel = makeGamePanel(rules, summaryPanel, game)
-        panel.startNewGame(listOf(player))
 
-        val listener = mockk<DartboardListener>(relaxed = true)
-        panel.dartboard.addDartboardListener(listener)
+        withGamePanel(rules, summaryPanel, game) { panel ->
+            panel.startNewGame(listOf(player))
 
-        panel.doAiTurn(beastDartsModel())
+            val listener = mockk<DartboardListener>(relaxed = true)
+            panel.dartboard.addDartboardListener(listener)
 
-        verify { listener.dartThrown(Dart(20, 3)) }
+            panel.doAiTurn(beastDartsModel())
+
+            verify { listener.dartThrown(Dart(20, 3)) }
+        }
     }
 
     @Test
@@ -236,21 +246,22 @@ class TestGamePanelDartzee: AbstractTest()
         every { carousel.initialised } returns true
 
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
-        val panel = makeGamePanel(rules, summaryPanel, game)
-        panel.loadGame()
+        withGamePanel(rules, summaryPanel, game) { panel ->
+            panel.loadGame()
 
-        val listener = mockk<DartboardListener>(relaxed = true)
-        panel.dartboard.addDartboardListener(listener)
+            val listener = mockk<DartboardListener>(relaxed = true)
+            panel.dartboard.addDartboardListener(listener)
 
-        val model = beastDartsModel(dartzeePlayStyle = DartzeePlayStyle.CAUTIOUS)
-        panel.doAiTurn(model)
-        panel.doAiTurn(model)
-        panel.doAiTurn(model)
+            val model = beastDartsModel(dartzeePlayStyle = DartzeePlayStyle.CAUTIOUS)
+            panel.doAiTurn(model)
+            panel.doAiTurn(model)
+            panel.doAiTurn(model)
 
-        verifySequence {
-            listener.dartThrown(Dart(20, 1))
-            listener.dartThrown(Dart(20, 1))
-            listener.dartThrown(Dart(25, 2))
+            verifySequence {
+                listener.dartThrown(Dart(20, 1))
+                listener.dartThrown(Dart(20, 1))
+                listener.dartThrown(Dart(25, 2))
+            }
         }
     }
 
@@ -267,24 +278,25 @@ class TestGamePanelDartzee: AbstractTest()
         val carousel = DartzeeRuleCarousel(rules)
 
         val summaryPanel = DartzeeRuleSummaryPanel(carousel)
-        val panel = makeGamePanel(rules, summaryPanel, game)
-        panel.loadGame()
+        withGamePanel(rules, summaryPanel, game) { panel ->
+            panel.loadGame()
 
-        panel.doAiTurn(model)
-        panel.doAiTurn(model)
-        panel.doAiTurn(model)
+            panel.doAiTurn(model)
+            panel.doAiTurn(model)
+            panel.doAiTurn(model)
 
-        panel.saveDartsAndProceed()
+            panel.saveDartsAndProceed()
 
-        val results = DartzeeRoundResultEntity().retrieveEntities()
-        results.size shouldBe 1
+            val results = DartzeeRoundResultEntity().retrieveEntities()
+            results.size shouldBe 1
 
-        val result = results.first()
-        result.ruleNumber shouldBe 2
-        result.success shouldBe true
+            val result = results.first()
+            result.ruleNumber shouldBe 2
+            result.success shouldBe true
 
-        carousel.getAvailableRuleTiles().size shouldBe 1
-        carousel.getAvailableRuleTiles().first().dto shouldBe twoBlackOneWhite
+            carousel.getAvailableRuleTiles().size shouldBe 1
+            carousel.getAvailableRuleTiles().first().dto shouldBe twoBlackOneWhite
+        }
     }
 
     private fun GamePanelDartzee.getPlayerState() = getPlayerStates().first()
@@ -328,18 +340,21 @@ class TestGamePanelDartzee: AbstractTest()
         return game
     }
 
-    private fun makeGamePanel(dtos: List<DartzeeRuleDto>,
+    private fun withGamePanel(dtos: List<DartzeeRuleDto>,
                               summaryPanel: DartzeeRuleSummaryPanel = mockk(relaxed = true),
                               game: GameEntity = insertGame(),
                               totalPlayers: Int = 1,
-                              parentWindow: AbstractDartsGameScreen = mockk(relaxed = true)): GamePanelDartzee
+                              parentWindow: AbstractDartsGameScreen = mockk(relaxed = true),
+                              testFn: (gamePanel: GamePanelDartzee) -> Unit)
     {
-        return GamePanelDartzee(
-            parentWindow,
-            game,
-            totalPlayers,
-            dtos,
-            summaryPanel
-        )
+        val gamePanel = GamePanelDartzee(parentWindow, game, totalPlayers, dtos, summaryPanel)
+        try
+        {
+            testFn(gamePanel)
+        }
+        finally
+        {
+            //watch this space...
+        }
     }
 }

--- a/src/test/kotlin/dartzee/utils/TestDartboardUtil.kt
+++ b/src/test/kotlin/dartzee/utils/TestDartboardUtil.kt
@@ -98,6 +98,7 @@ class TestDartboardUtil : AbstractRegistryTest()
         }
 
         fakeSegment.points.shouldHaveSize(40401)
+        fakeSegment.computeEdgePoints()
 
         //Four corners and four edge mid-points
         assertColourForPointAndSegment(Point(0, 0), fakeSegment, wrapper, Color.YELLOW)

--- a/src/test/kotlin/dartzee/utils/TestGeometryUtil.kt
+++ b/src/test/kotlin/dartzee/utils/TestGeometryUtil.kt
@@ -108,7 +108,7 @@ class TestGeometryUtil: AbstractTest()
 
     private fun assertAverage(expected: Point, vararg points: Point)
     {
-        val list = points.toList()
+        val list = points.toSet()
         getAverage(list) shouldBe expected
     }
 


### PR DESCRIPTION
First steps towards trying to deal with the crazy Dartboard memory usage.

This PR adds settings to `build.gradle` so we can run VisualVM on the tests / actual application. I've also removed one of the hashmaps from Dartboard, and made a few efficiency gains moving from lists to sets. 

Also fixed a genuine memory leak in tests with the cached `syncSummaryPanel`, which accrued `MenuScreens` as listeners which then couldn't be collected (along with their 400x400 dartboards). The `MenuScreen` will no longer leak, and as an added bonus the dartboard it renders is a static image, releasing the points/dartboardsegments that were used for the render to be GC'd. 