### PR TITLE
Introduce separate 'StatefulSegment', and only use where the points are needed

### DIFF
--- a/src/main/kotlin/dartzee/dartzee/DartzeeAimCalculator.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeAimCalculator.kt
@@ -24,10 +24,12 @@ class DartzeeAimCalculator
         val validSegments = segmentStatus.validSegments.map { miniDartboard.getSegment(it.score, it.type)!! }
 
         val segmentsToConsiderAimingFor = if (aggressive) scoringSegments else validSegments
+        val dataSegmentsToConsiderAimingFor = segmentsToConsiderAimingFor.map { it.toDataSegment() }
 
         //Shortcut straight to the bullseye if all outer singles, inner singles, trebles and bull are valid
         val innerSegments = getAllPossibleSegments().filter { !it.isMiss() && (it.type != SegmentType.DOUBLE || it.score == 25) }
-        if (segmentsToConsiderAimingFor.containsAll(innerSegments))
+
+        if (dataSegmentsToConsiderAimingFor.containsAll(innerSegments))
         {
             return dartboard.centerPoint
         }

--- a/src/main/kotlin/dartzee/dartzee/DartzeeSegmentFactory.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeSegmentFactory.kt
@@ -5,12 +5,12 @@ import dartzee.screen.DartboardSegmentSelectDialog
 
 abstract class AbstractDartzeeSegmentFactory
 {
-    abstract fun selectSegments(segments: HashSet<DartboardSegment>): HashSet<DartboardSegment>
+    abstract fun selectSegments(segments: Set<DartboardSegment>): Set<DartboardSegment>
 }
 
 class DartzeeSegmentFactory: AbstractDartzeeSegmentFactory()
 {
-    override fun selectSegments(segments: HashSet<DartboardSegment>): HashSet<DartboardSegment>
+    override fun selectSegments(segments: Set<DartboardSegment>): Set<DartboardSegment>
     {
         val dlg = DartboardSegmentSelectDialog(segments)
         dlg.isVisible = true

--- a/src/main/kotlin/dartzee/dartzee/dart/DartzeeDartRuleColour.kt
+++ b/src/main/kotlin/dartzee/dartzee/dart/DartzeeDartRuleColour.kt
@@ -3,7 +3,7 @@ package dartzee.dartzee.dart
 import dartzee.`object`.DEFAULT_COLOUR_WRAPPER
 import dartzee.`object`.DartboardSegment
 import dartzee.utils.DartsColour
-import dartzee.utils.getColourForPointAndSegment
+import dartzee.utils.getColourForSegment
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.awt.Color
@@ -52,7 +52,7 @@ class DartzeeDartRuleColour: AbstractDartzeeDartRuleConfigurable(), ActionListen
             return false
         }
 
-        val color = getColourForPointAndSegment(null, segment, DEFAULT_COLOUR_WRAPPER)
+        val color = getColourForSegment(segment, DEFAULT_COLOUR_WRAPPER)
 
         return (color == DartsColour.DARTBOARD_BLACK && black)
                 || (color == Color.WHITE && white)

--- a/src/main/kotlin/dartzee/dartzee/dart/DartzeeDartRuleCustom.kt
+++ b/src/main/kotlin/dartzee/dartzee/dart/DartzeeDartRuleCustom.kt
@@ -2,7 +2,6 @@ package dartzee.dartzee.dart
 
 import dartzee.`object`.DartboardSegment
 import dartzee.core.bean.addUpdateListener
-import dartzee.utils.DartsDatabaseUtil
 import dartzee.utils.InjectedThings
 import org.w3c.dom.Document
 import org.w3c.dom.Element
@@ -14,7 +13,7 @@ import javax.swing.JTextField
 
 class DartzeeDartRuleCustom: AbstractDartzeeDartRuleConfigurable(), ActionListener
 {
-    var segments = hashSetOf<DartboardSegment>()
+    val segments = mutableSetOf<DartboardSegment>()
     var name = ""
 
     val btnConfigure = JButton("Configure")
@@ -69,7 +68,9 @@ class DartzeeDartRuleCustom: AbstractDartzeeDartRuleConfigurable(), ActionListen
     {
         if (e?.source == btnConfigure)
         {
-            segments = InjectedThings.dartzeeSegmentFactory.selectSegments(segments)
+            val updatedSelection = InjectedThings.dartzeeSegmentFactory.selectSegments(segments.toSet())
+            segments.clear()
+            segments.addAll(updatedSelection)
         }
 
         name = tfName.text

--- a/src/main/kotlin/dartzee/object/DartboardSegment.kt
+++ b/src/main/kotlin/dartzee/object/DartboardSegment.kt
@@ -1,11 +1,8 @@
 package dartzee.`object`
 
-import dartzee.core.obj.HashMapList
 import dartzee.core.util.getAttributeInt
 import dartzee.core.util.setAttributeAny
-import dartzee.utils.getColourForPointAndSegment
 import org.w3c.dom.Element
-import java.awt.Point
 
 const val MISS_FUDGE_FACTOR = 1805
 
@@ -14,14 +11,6 @@ const val MISS_FUDGE_FACTOR = 1805
  */
 data class DartboardSegment(val type: SegmentType, val score: Int)
 {
-    //The Points this segment contains
-    val points = mutableSetOf<Point>()
-    val edgePoints = mutableSetOf<Point>()
-
-    //For tracking edge points
-    private val hmXCoordToPoints = HashMapList<Int, Point>()
-    private val hmYCoordToPoints = HashMapList<Int, Point>()
-
     /**
      * Helpers
      */
@@ -30,36 +19,7 @@ data class DartboardSegment(val type: SegmentType, val score: Int)
     fun getMultiplier() = type.getMultiplier()
     fun getTotal(): Int = score * getMultiplier()
 
-    fun addPoint(pt: Point)
-    {
-        points.add(pt)
-
-        hmXCoordToPoints.putInList(pt.x, pt)
-        hmYCoordToPoints.putInList(pt.y, pt)
-    }
-
-    fun getColorMap(colourWrapper: ColourWrapper?) = points.map { pt -> pt to getColourForPointAndSegment(pt, this, colourWrapper) }
-    fun containsPoint(point: Point) = points.contains(point)
-
     override fun toString() = "$score ($type)"
-
-    fun isEdgePoint(pt: Point?): Boolean
-    {
-        pt ?: return false
-        return edgePoints.contains(pt)
-    }
-
-    fun computeEdgePoints()
-    {
-        val yMins: List<Point> = hmXCoordToPoints.values.map { points -> points.minBy { it.y }!! }
-        val yMaxes: List<Point> = hmXCoordToPoints.values.map { points -> points.maxBy { it.y }!! }
-        val xMins: List<Point> = hmYCoordToPoints.values.map { points -> points.minBy { it.x }!! }
-        val xMaxes: List<Point> = hmYCoordToPoints.values.map { points -> points.maxBy { it.x }!! }
-        edgePoints.addAll(yMins + yMaxes + xMins + xMaxes)
-
-        hmXCoordToPoints.clear()
-        hmYCoordToPoints.clear()
-    }
 
     fun getRoughProbability(): Double {
         return type.getRoughSize(score).toDouble() / getRoughScoringArea()

--- a/src/main/kotlin/dartzee/object/StatefulSegment.kt
+++ b/src/main/kotlin/dartzee/object/StatefulSegment.kt
@@ -1,0 +1,60 @@
+package dartzee.`object`
+
+import dartzee.core.obj.HashMapList
+import dartzee.utils.getColourForPointAndSegment
+import java.awt.Point
+
+/**
+ * Stateful version of DartboardSegment, with all its points and edge points
+ */
+class StatefulSegment(val type: SegmentType, val score: Int)
+{
+    //The Points this segment contains
+    val points = mutableSetOf<Point>()
+    val edgePoints = mutableSetOf<Point>()
+
+    //For tracking edge points
+    private val hmXCoordToPoints = HashMapList<Int, Point>()
+    private val hmYCoordToPoints = HashMapList<Int, Point>()
+
+    fun toDataSegment() = DartboardSegment(type, score)
+
+    /**
+     * Helpers
+     */
+    fun isMiss() = type == SegmentType.MISS || type == SegmentType.MISSED_BOARD
+    fun isDoubleExcludingBull() = type == SegmentType.DOUBLE && score != 25
+    fun getTotal(): Int = score * type.getMultiplier()
+
+    fun addPoint(pt: Point)
+    {
+        points.add(pt)
+
+        hmXCoordToPoints.putInList(pt.x, pt)
+        hmYCoordToPoints.putInList(pt.y, pt)
+    }
+
+    fun getColorMap(colourWrapper: ColourWrapper?) = points.map { pt -> pt to getColourForPointAndSegment(pt, this, colourWrapper) }
+    fun containsPoint(point: Point) = points.contains(point)
+
+    override fun toString() = "$score ($type)"
+
+    fun isEdgePoint(pt: Point?): Boolean
+    {
+        pt ?: return false
+        return edgePoints.contains(pt)
+    }
+
+    fun computeEdgePoints()
+    {
+        val yMins: List<Point> = hmXCoordToPoints.values.map { points -> points.minBy { it.y }!! }
+        val yMaxes: List<Point> = hmXCoordToPoints.values.map { points -> points.maxBy { it.y }!! }
+        val xMins: List<Point> = hmYCoordToPoints.values.map { points -> points.minBy { it.x }!! }
+        val xMaxes: List<Point> = hmYCoordToPoints.values.map { points -> points.maxBy { it.x }!! }
+        edgePoints.addAll(yMins + yMaxes + xMins + xMaxes)
+
+        hmXCoordToPoints.clear()
+        hmYCoordToPoints.clear()
+    }
+}
+

--- a/src/main/kotlin/dartzee/screen/DartboardSegmentSelectDialog.kt
+++ b/src/main/kotlin/dartzee/screen/DartboardSegmentSelectDialog.kt
@@ -6,7 +6,7 @@ import dartzee.utils.DartsColour
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
-class DartboardSegmentSelectDialog(private val segments: HashSet<DartboardSegment>): SimpleDialog()
+class DartboardSegmentSelectDialog(private val segments: Set<DartboardSegment>): SimpleDialog()
 {
     private val dartboard = DartboardSegmentSelector()
 
@@ -32,7 +32,7 @@ class DartboardSegmentSelectDialog(private val segments: HashSet<DartboardSegmen
         dartboard.initState(segments)
     }
 
-    fun getSelection(): HashSet<DartboardSegment>
+    fun getSelection(): Set<DartboardSegment>
     {
         return dartboard.selectedSegments
     }
@@ -44,7 +44,7 @@ class DartboardSegmentSelectDialog(private val segments: HashSet<DartboardSegmen
 
     override fun cancelPressed()
     {
-        dartboard.selectedSegments = segments
+        dartboard.selectedSegments = segments.toMutableSet()
         dispose()
     }
 }

--- a/src/main/kotlin/dartzee/screen/DartboardSegmentSelector.kt
+++ b/src/main/kotlin/dartzee/screen/DartboardSegmentSelector.kt
@@ -3,17 +3,18 @@ package dartzee.screen
 import dartzee.`object`.ColourWrapper
 import dartzee.`object`.DEFAULT_COLOUR_WRAPPER
 import dartzee.`object`.DartboardSegment
+import dartzee.`object`.StatefulSegment
 import dartzee.utils.DartsColour
-import dartzee.utils.getColourForPointAndSegment
+import dartzee.utils.getColourForSegment
 import java.awt.Color
 import java.awt.Point
 import java.awt.event.MouseEvent
 
 class DartboardSegmentSelector(width: Int = 500, height: Int = 500): Dartboard(width, height)
 {
-    var selectedSegments = hashSetOf<DartboardSegment>()
+    var selectedSegments = mutableSetOf<DartboardSegment>()
 
-    private var lastDraggedSegment: DartboardSegment? = null
+    private var lastDraggedSegment: StatefulSegment? = null
 
     init
     {
@@ -21,14 +22,14 @@ class DartboardSegmentSelector(width: Int = 500, height: Int = 500): Dartboard(w
         renderScoreLabels = true
     }
 
-    fun initState(initialSelection: HashSet<DartboardSegment>)
+    fun initState(initialSelection: Set<DartboardSegment>)
     {
-        initialSelection.forEach {
-            val mySegment = getSegment(it.score, it.type) ?: return
+        initialSelection.forEach { dataSegment ->
+            val mySegment = getSegment(dataSegment.score, dataSegment.type) ?: return
 
-            selectedSegments.add(mySegment)
+            selectedSegments.add(dataSegment)
 
-            val col = getColourForPointAndSegment(null, mySegment, DEFAULT_COLOUR_WRAPPER)
+            val col = getColourForSegment(dataSegment, DEFAULT_COLOUR_WRAPPER)
             colourSegment(mySegment, col)
         }
     }
@@ -47,7 +48,7 @@ class DartboardSegmentSelector(width: Int = 500, height: Int = 500): Dartboard(w
         toggleSegment(segment)
     }
 
-    private fun toggleSegment(segment: DartboardSegment)
+    private fun toggleSegment(segment: StatefulSegment)
     {
         lastDraggedSegment = segment
         if (segment.isMiss())
@@ -55,17 +56,18 @@ class DartboardSegmentSelector(width: Int = 500, height: Int = 500): Dartboard(w
             return
         }
 
-        if (selectedSegments.contains(segment))
+        val dataSegment = segment.toDataSegment()
+        if (selectedSegments.contains(dataSegment))
         {
-            selectedSegments.remove(segment)
+            selectedSegments.remove(dataSegment)
 
             colourSegment(segment, DartsColour.TRANSPARENT)
         }
         else
         {
-            selectedSegments.add(segment)
+            selectedSegments.add(dataSegment)
 
-            val col = getColourForPointAndSegment(null, segment, DEFAULT_COLOUR_WRAPPER)
+            val col = getColourForSegment(dataSegment, DEFAULT_COLOUR_WRAPPER)
             colourSegment(segment, col)
         }
     }

--- a/src/main/kotlin/dartzee/utils/DartboardUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartboardUtil.kt
@@ -1,9 +1,6 @@
 package dartzee.utils
 
-import dartzee.`object`.ColourWrapper
-import dartzee.`object`.Dart
-import dartzee.`object`.DartboardSegment
-import dartzee.`object`.SegmentType
+import dartzee.`object`.*
 import dartzee.screen.Dartboard
 import java.awt.Color
 import java.awt.Point
@@ -43,18 +40,18 @@ fun getAdjacentNumbers(number: Int): MutableList<Int>
     return mutableListOf(numberOrder[ix-1], numberOrder[ix+1])
 }
 
-fun factorySegmentForPoint(dartPt: Point, centerPt: Point, diameter: Double): DartboardSegment
+fun factorySegmentForPoint(dartPt: Point, centerPt: Point, diameter: Double): StatefulSegment
 {
     val radius = getDistance(dartPt, centerPt)
     val ratio = 2 * radius / diameter
 
     if (ratio < RATIO_INNER_BULL)
     {
-        return DartboardSegment(SegmentType.DOUBLE, 25)
+        return StatefulSegment(SegmentType.DOUBLE, 25)
     }
     else if (ratio < RATIO_OUTER_BULL)
     {
-        return DartboardSegment(SegmentType.OUTER_SINGLE, 25)
+        return StatefulSegment(SegmentType.OUTER_SINGLE, 25)
     }
 
     //We've not hit the bullseye, so do other calculations to work out score/multiplier
@@ -62,7 +59,7 @@ fun factorySegmentForPoint(dartPt: Point, centerPt: Point, diameter: Double): Da
     val score = getScoreForAngle(angle)
     val type = calculateTypeForRatioNonBullseye(ratio)
 
-    return DartboardSegment(type, score)
+    return StatefulSegment(type, score)
 }
 
 /**
@@ -114,7 +111,7 @@ fun getPotentialAimPoints(centerPt: Point, diameter: Double): Set<AimPoint>
     return points.toSet()
 }
 
-fun getColourForPointAndSegment(pt: Point?, segment: DartboardSegment, colourWrapper: ColourWrapper?): Color
+fun getColourForPointAndSegment(pt: Point?, segment: StatefulSegment, colourWrapper: ColourWrapper?): Color
 {
     val colourWrapperToUse = colourWrapper ?: getColourWrapperFromPrefs()
 
@@ -126,6 +123,12 @@ fun getColourForPointAndSegment(pt: Point?, segment: DartboardSegment, colourWra
         return edgeColour
     }
 
+    return getColourFromHashMap(segment.toDataSegment(), colourWrapperToUse)
+}
+
+fun getColourForSegment(segment: DartboardSegment, colourWrapper: ColourWrapper?): Color
+{
+    val colourWrapperToUse = colourWrapper ?: getColourWrapperFromPrefs()
     return getColourFromHashMap(segment, colourWrapperToUse)
 }
 

--- a/src/test/kotlin/dartzee/ai/TestStrategyUtils.kt
+++ b/src/test/kotlin/dartzee/ai/TestStrategyUtils.kt
@@ -1,8 +1,8 @@
 package dartzee.ai
 
 import dartzee.`object`.ColourWrapper
-import dartzee.`object`.DartboardSegment
 import dartzee.`object`.SegmentType
+import dartzee.`object`.StatefulSegment
 import dartzee.helper.AbstractTest
 import dartzee.screen.Dartboard
 import getPointForScore
@@ -27,7 +27,7 @@ class TestStrategyUtils: AbstractTest()
         {
             super.paintDartboard(colourWrapper, listen, cached)
 
-            val segment = DartboardSegment(SegmentType.TREBLE, 20)
+            val segment = StatefulSegment(SegmentType.TREBLE, 20)
             segment.addPoint(Point(1, 7))
             segment.addPoint(Point(3, 3))
             segment.addPoint(Point(5, 2))

--- a/src/test/kotlin/dartzee/dartzee/dart/TestDartzeeDartRuleCustom.kt
+++ b/src/test/kotlin/dartzee/dartzee/dart/TestDartzeeDartRuleCustom.kt
@@ -27,7 +27,7 @@ class TestDartzeeDartRuleCustom: AbstractDartzeeRuleTest<DartzeeDartRuleCustom>(
     fun `a custom rule with at least one segment is valid`()
     {
         val rule = DartzeeDartRuleCustom()
-        rule.segments = hashSetOf(doubleTwenty)
+        rule.segments.add(doubleTwenty)
 
         rule.validate().shouldBeEmpty()
     }
@@ -56,7 +56,7 @@ class TestDartzeeDartRuleCustom: AbstractDartzeeRuleTest<DartzeeDartRuleCustom>(
     fun `segment validation`()
     {
         val rule = DartzeeDartRuleCustom()
-        rule.segments = hashSetOf(doubleTwenty, trebleNineteen)
+        rule.segments.addAll(setOf(doubleTwenty, trebleNineteen))
 
         rule.isValidSegment(doubleTwenty) shouldBe true
         rule.isValidSegment(trebleNineteen) shouldBe true
@@ -68,7 +68,7 @@ class TestDartzeeDartRuleCustom: AbstractDartzeeRuleTest<DartzeeDartRuleCustom>(
     {
         val rule = DartzeeDartRuleCustom()
 
-        rule.segments = hashSetOf(doubleTwenty, outerBull, trebleNineteen)
+        rule.segments.addAll(setOf(doubleTwenty, outerBull, trebleNineteen))
         rule.name = "Foo"
 
         val xml = rule.toDbString()

--- a/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
@@ -44,7 +44,7 @@ class TestDartzeeRuleEntity: AbstractEntityTest<DartzeeRuleEntity>()
         val rowId = entity.assignRowId()
 
         val customRule = DartzeeDartRuleCustom()
-        customRule.segments = getAllPossibleSegments().toHashSet()
+        customRule.segments.addAll(getAllPossibleSegments())
 
         entity.dart1Rule = customRule.toDbString()
         entity.dart2Rule = customRule.toDbString()

--- a/src/test/kotlin/dartzee/helper/FakeDartzeeFactories.kt
+++ b/src/test/kotlin/dartzee/helper/FakeDartzeeFactories.kt
@@ -24,11 +24,11 @@ class FakeDartzeeTemplateFactory(private val newTemplate: DartzeeTemplateEntity?
             }
 }
 
-class FakeDartzeeSegmentFactory(private val desiredSegments: HashSet<DartboardSegment>): AbstractDartzeeSegmentFactory()
+class FakeDartzeeSegmentFactory(private val desiredSegments: Set<DartboardSegment>): AbstractDartzeeSegmentFactory()
 {
-    var segmentsPassedIn: HashSet<DartboardSegment> = HashSet()
+    var segmentsPassedIn: Set<DartboardSegment> = emptySet()
 
-    override fun selectSegments(segments: HashSet<DartboardSegment>): HashSet<DartboardSegment> {
+    override fun selectSegments(segments: Set<DartboardSegment>): Set<DartboardSegment> {
         segmentsPassedIn = segments
         return desiredSegments
     }

--- a/src/test/kotlin/dartzee/object/TestDartboardSegment.kt
+++ b/src/test/kotlin/dartzee/object/TestDartboardSegment.kt
@@ -4,7 +4,6 @@ import dartzee.*
 import dartzee.helper.AbstractTest
 import io.kotlintest.shouldBe
 import org.junit.Test
-import java.awt.Point
 
 class TestDartboardSegment: AbstractTest()
 {
@@ -47,105 +46,4 @@ class TestDartboardSegment: AbstractTest()
         missedBoard.getTotal() shouldBe 0
         missTwenty.getTotal() shouldBe 0
     }
-
-    @Test
-    fun `Should support adding points`()
-    {
-        val segment = doubleNineteen.copy()
-
-        val points = listOf(Point(1, 0), Point(0, 1), Point(20, -5))
-        points.forEach { segment.addPoint(it) }
-
-        segment.points shouldBe points.toMutableSet()
-    }
-
-
-    /**
-     * X X X X
-     * X O O X
-     * X O O X
-     * X X X X
-     */
-    @Test
-    fun `Should report edge points correctly - square`()
-    {
-        val segment = doubleNineteen.copy()
-
-        val xRange = 0..3
-        val yRange = 0..3
-
-        val pts = xRange.map { x -> yRange.map { y -> Point(x, y) } }.flatten()
-        pts.forEach { segment.addPoint(it) }
-        segment.computeEdgePoints()
-
-        //Corners
-        segment.isEdgePoint(Point(0, 0)) shouldBe true
-        segment.isEdgePoint(Point(0, 3)) shouldBe true
-        segment.isEdgePoint(Point(3, 0)) shouldBe true
-        segment.isEdgePoint(Point(3, 3)) shouldBe true
-
-        //Random other edges
-        segment.isEdgePoint(Point(0, 1)) shouldBe true
-        segment.isEdgePoint(Point(0, 2)) shouldBe true
-        segment.isEdgePoint(Point(3, 1)) shouldBe true
-        segment.isEdgePoint(Point(3, 2)) shouldBe true
-        segment.isEdgePoint(Point(1, 0)) shouldBe true
-        segment.isEdgePoint(Point(2, 0)) shouldBe true
-        segment.isEdgePoint(Point(1, 3)) shouldBe true
-        segment.isEdgePoint(Point(2, 3)) shouldBe true
-
-        //Inner points
-        segment.isEdgePoint(Point(1, 1)) shouldBe false
-        segment.isEdgePoint(Point(1, 2)) shouldBe false
-        segment.isEdgePoint(Point(2, 1)) shouldBe false
-        segment.isEdgePoint(Point(2, 2)) shouldBe false
-
-        //Null case
-        segment.isEdgePoint(null) shouldBe false
-    }
-
-    /**         X
-     *        X X
-     *      X O X
-     *    X O O X
-     *  X X X X X
-     *
-     *  ^ This.
-     */
-    @Test
-    fun `Should report edge points correctly - triangle`()
-    {
-        val segment = doubleNineteen.copy()
-
-        val xRange = 0..4
-        val yRange = 0..4
-
-        val pts = xRange.map { x -> yRange.filter{ it <= x }.map { y -> Point(x, y) } }.flatten()
-        pts.forEach { segment.addPoint(it) }
-        segment.computeEdgePoints()
-
-        //Bottom edge
-        segment.isEdgePoint(Point(0, 0)) shouldBe true
-        segment.isEdgePoint(Point(1, 0)) shouldBe true
-        segment.isEdgePoint(Point(2, 0)) shouldBe true
-        segment.isEdgePoint(Point(3, 0)) shouldBe true
-        segment.isEdgePoint(Point(4, 0)) shouldBe true
-
-        //Right edge
-        segment.isEdgePoint(Point(4, 1)) shouldBe true
-        segment.isEdgePoint(Point(4, 2)) shouldBe true
-        segment.isEdgePoint(Point(4, 3)) shouldBe true
-        segment.isEdgePoint(Point(4, 4)) shouldBe true
-
-        //Diagonal
-        segment.isEdgePoint(Point(1, 1)) shouldBe true
-        segment.isEdgePoint(Point(2, 2)) shouldBe true
-        segment.isEdgePoint(Point(3, 3)) shouldBe true
-
-        //Inner points
-        segment.isEdgePoint(Point(2, 1)) shouldBe false
-        segment.isEdgePoint(Point(3, 1)) shouldBe false
-        segment.isEdgePoint(Point(3, 2)) shouldBe false
-    }
-
 }

--- a/src/test/kotlin/dartzee/object/TestStatefulSegment.kt
+++ b/src/test/kotlin/dartzee/object/TestStatefulSegment.kt
@@ -1,0 +1,108 @@
+package dartzee.`object`
+
+import dartzee.helper.AbstractTest
+import io.kotlintest.shouldBe
+import org.junit.Test
+import java.awt.Point
+
+class TestStatefulSegment: AbstractTest()
+{
+    @Test
+    fun `Should support adding points`()
+    {
+        val segment = StatefulSegment(SegmentType.DOUBLE, 19)
+
+        val points = listOf(Point(1, 0), Point(0, 1), Point(20, -5))
+        points.forEach { segment.addPoint(it) }
+
+        segment.points shouldBe points.toMutableSet()
+    }
+
+    /**
+     * X X X X
+     * X O O X
+     * X O O X
+     * X X X X
+     */
+    @Test
+    fun `Should report edge points correctly - square`()
+    {
+        val segment = StatefulSegment(SegmentType.DOUBLE, 19)
+
+        val xRange = 0..3
+        val yRange = 0..3
+
+        val pts = xRange.map { x -> yRange.map { y -> Point(x, y) } }.flatten()
+        pts.forEach { segment.addPoint(it) }
+        segment.computeEdgePoints()
+
+        //Corners
+        segment.isEdgePoint(Point(0, 0)) shouldBe true
+        segment.isEdgePoint(Point(0, 3)) shouldBe true
+        segment.isEdgePoint(Point(3, 0)) shouldBe true
+        segment.isEdgePoint(Point(3, 3)) shouldBe true
+
+        //Random other edges
+        segment.isEdgePoint(Point(0, 1)) shouldBe true
+        segment.isEdgePoint(Point(0, 2)) shouldBe true
+        segment.isEdgePoint(Point(3, 1)) shouldBe true
+        segment.isEdgePoint(Point(3, 2)) shouldBe true
+        segment.isEdgePoint(Point(1, 0)) shouldBe true
+        segment.isEdgePoint(Point(2, 0)) shouldBe true
+        segment.isEdgePoint(Point(1, 3)) shouldBe true
+        segment.isEdgePoint(Point(2, 3)) shouldBe true
+
+        //Inner points
+        segment.isEdgePoint(Point(1, 1)) shouldBe false
+        segment.isEdgePoint(Point(1, 2)) shouldBe false
+        segment.isEdgePoint(Point(2, 1)) shouldBe false
+        segment.isEdgePoint(Point(2, 2)) shouldBe false
+
+        //Null case
+        segment.isEdgePoint(null) shouldBe false
+    }
+
+    /**         X
+     *        X X
+     *      X O X
+     *    X O O X
+     *  X X X X X
+     *
+     *  ^ This.
+     */
+    @Test
+    fun `Should report edge points correctly - triangle`()
+    {
+        val segment = StatefulSegment(SegmentType.DOUBLE, 19)
+
+        val xRange = 0..4
+        val yRange = 0..4
+
+        val pts = xRange.map { x -> yRange.filter{ it <= x }.map { y -> Point(x, y) } }.flatten()
+        pts.forEach { segment.addPoint(it) }
+        segment.computeEdgePoints()
+
+        //Bottom edge
+        segment.isEdgePoint(Point(0, 0)) shouldBe true
+        segment.isEdgePoint(Point(1, 0)) shouldBe true
+        segment.isEdgePoint(Point(2, 0)) shouldBe true
+        segment.isEdgePoint(Point(3, 0)) shouldBe true
+        segment.isEdgePoint(Point(4, 0)) shouldBe true
+
+        //Right edge
+        segment.isEdgePoint(Point(4, 1)) shouldBe true
+        segment.isEdgePoint(Point(4, 2)) shouldBe true
+        segment.isEdgePoint(Point(4, 3)) shouldBe true
+        segment.isEdgePoint(Point(4, 4)) shouldBe true
+
+        //Diagonal
+        segment.isEdgePoint(Point(1, 1)) shouldBe true
+        segment.isEdgePoint(Point(2, 2)) shouldBe true
+        segment.isEdgePoint(Point(3, 3)) shouldBe true
+
+        //Inner points
+        segment.isEdgePoint(Point(2, 1)) shouldBe false
+        segment.isEdgePoint(Point(3, 1)) shouldBe false
+        segment.isEdgePoint(Point(3, 2)) shouldBe false
+    }
+}

--- a/src/test/kotlin/dartzee/screen/TestDartboardSegmentSelector.kt
+++ b/src/test/kotlin/dartzee/screen/TestDartboardSegmentSelector.kt
@@ -6,10 +6,11 @@ import dartzee.core.helper.makeMouseEvent
 import dartzee.doubleNineteen
 import dartzee.getColor
 import dartzee.helper.AbstractTest
+import dartzee.singleNineteen
 import dartzee.utils.DartsColour
+import dartzee.utils.getAverage
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldHaveSize
-import io.kotlintest.matchers.collections.shouldNotBeEmpty
 import io.kotlintest.shouldBe
 import org.junit.Test
 import java.awt.Color
@@ -106,14 +107,17 @@ class TestDartboardSegmentSelector: AbstractTest()
         val dartboard = DartboardSegmentSelector(100, 100)
         dartboard.paintDartboard()
 
-        dartboard.initState(hashSetOf(doubleNineteen))
+        dartboard.initState(hashSetOf(singleNineteen))
 
         val selectedSegment = dartboard.selectedSegments.first()
         assertNotNull(selectedSegment)
 
-        selectedSegment.points.shouldNotBeEmpty()
+        val pt = getAverage(dartboard.getPointsForSegment(19, SegmentType.OUTER_SINGLE))
+        val img = dartboard.dartboardImage!!
+
+        Color(img.getRGB(pt.x, pt.y)) shouldBe Color.WHITE
         selectedSegment.score shouldBe 19
-        selectedSegment.type shouldBe SegmentType.DOUBLE
+        selectedSegment.type shouldBe SegmentType.OUTER_SINGLE
     }
 
     @Test

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleVerificationPanel.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleVerificationPanel.kt
@@ -1,5 +1,6 @@
 package dartzee.screen.dartzee
 
+import dartzee.`object`.DartboardSegment
 import dartzee.`object`.SegmentType
 import dartzee.dartzee.DartzeeCalculator
 import dartzee.doClick
@@ -20,13 +21,11 @@ class TestDartzeeRuleVerificationPanel: AbstractTest()
     {
         val panel = DartzeeRuleVerificationPanel()
 
-        val d20 = panel.dartboard.getSegment(20, SegmentType.DOUBLE)!!
-
-        val dto = makeDartzeeRuleDto(calculationResult = makeDartzeeRuleCalculationResult(listOf(d20)))
+        val dto = makeDartzeeRuleDto(calculationResult = makeDartzeeRuleCalculationResult(listOf(DartboardSegment(SegmentType.DOUBLE, 20))))
 
         panel.updateRule(dto)
 
-        panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactly(d20)
+        panel.dartboard.segmentStatus!!.scoringSegments.shouldContainExactly(DartboardSegment(SegmentType.DOUBLE, 20))
     }
 
     @Test

--- a/src/test/kotlin/dartzee/utils/TestDartboardUtil.kt
+++ b/src/test/kotlin/dartzee/utils/TestDartboardUtil.kt
@@ -1,8 +1,8 @@
 package dartzee.utils
 
 import dartzee.`object`.ColourWrapper
-import dartzee.`object`.DartboardSegment
 import dartzee.`object`.SegmentType
+import dartzee.`object`.StatefulSegment
 import dartzee.helper.AbstractRegistryTest
 import io.kotlintest.matchers.collections.shouldContainAll
 import io.kotlintest.matchers.collections.shouldHaveSize
@@ -64,7 +64,7 @@ class TestDartboardUtil : AbstractRegistryTest()
         val segmentStr = "" + segment
         segmentStr shouldBe "$score ($segmentType)"
 
-        val drt = getDartForSegment(pt, segment)
+        val drt = getDartForSegment(pt, segment.toDataSegment())
 
         drt.score shouldBe score
         drt.multiplier shouldBe multiplier
@@ -88,7 +88,7 @@ class TestDartboardUtil : AbstractRegistryTest()
         val wrapper = ColourWrapper(DartsColour.TRANSPARENT)
         wrapper.edgeColour = Color.YELLOW
 
-        val fakeSegment = DartboardSegment(SegmentType.OUTER_SINGLE, 20)
+        val fakeSegment = StatefulSegment(SegmentType.OUTER_SINGLE, 20)
         for (x in 0..200)
         {
             for (y in 0..200)
@@ -120,7 +120,7 @@ class TestDartboardUtil : AbstractRegistryTest()
         assertColourForPointAndSegment(Point(100, 100), fakeSegment, wrapper, DartsColour.TRANSPARENT)
 
         //Now assign this to be a "miss" segment. We should no longer get the wireframe, even for an edge
-        val missSegment = DartboardSegment(SegmentType.MISS, 20)
+        val missSegment = StatefulSegment(SegmentType.MISS, 20)
         for (x in 0..200)
         {
             for (y in 0..200)
@@ -133,7 +133,7 @@ class TestDartboardUtil : AbstractRegistryTest()
         assertColourForPointAndSegment(Point(1, 1), missSegment, wrapper, DartsColour.TRANSPARENT)
     }
 
-    private fun assertColourForPointAndSegment(pt: Point, segment: DartboardSegment, wrapper: ColourWrapper?, expected: Color)
+    private fun assertColourForPointAndSegment(pt: Point, segment: StatefulSegment, wrapper: ColourWrapper?, expected: Color)
     {
         val color = getColourForPointAndSegment(pt, segment, wrapper)
         color shouldBe expected


### PR DESCRIPTION
Conceptually simplifies most of the codebase, which now deals with the simplified `DartboardSegment` data class.

Also much easier to track what's going on in heap dumps, as `DartboardSegment` instances can now be completely ignored as sources of leaked `Points`. 