### PR TITLE
JUnit5: Bump swing-test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     testImplementation "io.mockk:mockk:1.9.3"
     testImplementation "io.kotlintest:kotlintest-assertions:3.4.2"
-    testImplementation 'com.github.alexburlton:swing-test:0.3.0'
+    testImplementation 'com.github.alexburlton:swing-test:1.0.0'
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.1.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.1.0"
 }

--- a/src/test/kotlin/dartzee/TestUtils.kt
+++ b/src/test/kotlin/dartzee/TestUtils.kt
@@ -151,33 +151,3 @@ fun DefaultTableModel.getRows(columns: Int = columnCount): List<List<Any?>>
 }
 
 fun ScrollTable.firstRow(): List<Any?> = getRows().first()
-
-/**
- * TODO - improvements for swing-test
- */
-fun Component.shouldBeVisible()
-{
-    isVisible shouldBe true
-}
-fun Component.shouldNotBeVisible()
-{
-    isVisible shouldBe false
-}
-fun JCheckBox.unCheck()
-{
-    if (isSelected)
-    {
-        doClick()
-    }
-}
-fun awaitCondition(timeout: Int = 10000, condition: (() -> Boolean))
-{
-    val timer = DurationTimer()
-    while (!condition()) {
-        Thread.sleep(200)
-
-        if (timer.getDuration() > timeout) {
-            throw AssertionError("Timed out waiting for condition")
-        }
-    }
-}

--- a/src/test/kotlin/dartzee/screen/ai/TestAIConfigurationGolfDartPanel.kt
+++ b/src/test/kotlin/dartzee/screen/ai/TestAIConfigurationGolfDartPanel.kt
@@ -1,16 +1,12 @@
 package dartzee.screen.ai
 
-import com.github.alexburlton.swingtest.getChild
-import com.github.alexburlton.swingtest.shouldBeDisabled
-import com.github.alexburlton.swingtest.shouldBeEnabled
+import com.github.alexburlton.swingtest.*
 import dartzee.`object`.SegmentType
 import dartzee.core.bean.ComboBoxItem
 import dartzee.core.bean.items
 import dartzee.core.bean.selectedItemTyped
 import dartzee.helper.AbstractTest
 import dartzee.helper.makeDartsModel
-import dartzee.shouldBeVisible
-import dartzee.shouldNotBeVisible
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 import javax.swing.JComboBox

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
@@ -1,6 +1,8 @@
 package dartzee.screen.dartzee
 
 import com.github.alexburlton.swingtest.flushEdt
+import com.github.alexburlton.swingtest.shouldBeVisible
+import com.github.alexburlton.swingtest.shouldNotBeVisible
 import dartzee.bean.DartzeeDartRuleSelector
 import dartzee.core.bean.selectByClass
 import dartzee.core.helper.makeActionEvent
@@ -11,8 +13,6 @@ import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
 import dartzee.dartzee.total.DartzeeTotalRuleOdd
 import dartzee.dartzee.total.DartzeeTotalRulePrime
 import dartzee.helper.*
-import dartzee.shouldBeVisible
-import dartzee.shouldNotBeVisible
 import dartzee.utils.InjectedThings
 import io.kotlintest.matchers.collections.shouldBeEmpty
 import io.kotlintest.matchers.collections.shouldContainExactly

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorerPausable.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractDartsScorerPausable.kt
@@ -2,6 +2,7 @@ package dartzee.screen.game.scorer
 
 import com.github.alexburlton.swingtest.clickChild
 import com.github.alexburlton.swingtest.getChild
+import com.github.alexburlton.swingtest.shouldBeVisible
 import com.github.alexburlton.swingtest.shouldNotBeVisible
 import dartzee.core.helper.verifyNotCalled
 import dartzee.core.util.DateStatics
@@ -10,7 +11,6 @@ import dartzee.game.state.TestPlayerState
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertParticipant
 import dartzee.screen.game.GamePanelPausable
-import dartzee.shouldBeVisible
 import dartzee.shouldHaveColours
 import dartzee.utils.DartsColour
 import dartzee.utils.ResourceCache.ICON_PAUSE

--- a/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractScorer.kt
+++ b/src/test/kotlin/dartzee/screen/game/scorer/TestAbstractScorer.kt
@@ -1,9 +1,9 @@
 package dartzee.screen.game.scorer
 
+import com.github.alexburlton.swingtest.shouldBeVisible
+import com.github.alexburlton.swingtest.shouldNotBeVisible
 import dartzee.helper.AbstractTest
 import dartzee.helper.insertPlayer
-import dartzee.shouldBeVisible
-import dartzee.shouldNotBeVisible
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/dartzee/screen/preference/TestPreferencesPanelMisc.kt
+++ b/src/test/kotlin/dartzee/screen/preference/TestPreferencesPanelMisc.kt
@@ -1,6 +1,6 @@
 package dartzee.screen.preference
 
-import dartzee.unCheck
+import com.github.alexburlton.swingtest.uncheck
 import dartzee.utils.*
 import io.kotlintest.shouldBe
 
@@ -25,9 +25,9 @@ class TestPreferencesPanelMisc: AbstractPreferencePanelTest<PreferencesPanelMisc
         panel.slider.value = 20
         panel.nfLeaderboardSize.value = 100
 
-        panel.chckbxAiAutomaticallyFinish.unCheck()
-        panel.chckbxCheckForUpdates.unCheck()
-        panel.chckbxShowAnimations.unCheck()
+        panel.chckbxAiAutomaticallyFinish.uncheck()
+        panel.chckbxCheckForUpdates.uncheck()
+        panel.chckbxShowAnimations.uncheck()
     }
 
     override fun checkUiFieldValuesAreNonDefaults(panel: PreferencesPanelMisc)

--- a/src/test/kotlin/e2e/GameHelpers.kt
+++ b/src/test/kotlin/e2e/GameHelpers.kt
@@ -1,11 +1,11 @@
 package e2e
 
+import com.github.alexburlton.swingtest.awaitCondition
 import com.github.alexburlton.swingtest.clickChild
 import com.github.alexburlton.swingtest.getChild
 import dartzee.`object`.Dart
 import dartzee.ai.AimDart
 import dartzee.ai.DartsAiModel
-import dartzee.awaitCondition
 import dartzee.core.util.DateStatics
 import dartzee.core.util.getSortedValues
 import dartzee.db.DartEntity

--- a/src/test/kotlin/e2e/SimulationE2E.kt
+++ b/src/test/kotlin/e2e/SimulationE2E.kt
@@ -4,7 +4,7 @@ import com.github.alexburlton.swingtest.clickChild
 import com.github.alexburlton.swingtest.getChild
 import dartzee.ai.AimDart
 import dartzee.ai.SimulationRunner
-import dartzee.awaitCondition
+import com.github.alexburlton.swingtest.awaitCondition
 import dartzee.bean.ScrollTableDartsGame
 import dartzee.core.bean.NumberField
 import dartzee.core.bean.ScrollTable

--- a/src/test/kotlin/e2e/SimulationHelpers.kt
+++ b/src/test/kotlin/e2e/SimulationHelpers.kt
@@ -3,7 +3,7 @@ package e2e
 import com.github.alexburlton.swingtest.findChild
 import com.github.alexburlton.swingtest.flushEdt
 import com.github.alexburlton.swingtest.getChild
-import dartzee.awaitCondition
+import com.github.alexburlton.swingtest.awaitCondition
 import dartzee.helper.AbstractTest
 import dartzee.logging.CODE_SIMULATION_FINISHED
 import dartzee.screen.stats.player.PlayerStatisticsScreen

--- a/src/test/kotlin/e2e/TestGameLoadE2E.kt
+++ b/src/test/kotlin/e2e/TestGameLoadE2E.kt
@@ -1,8 +1,9 @@
 package e2e
 
+import com.github.alexburlton.swingtest.shouldBeVisible
 import dartzee.`object`.Dart
 import dartzee.`object`.GameLauncher
-import dartzee.awaitCondition
+import com.github.alexburlton.swingtest.awaitCondition
 import dartzee.core.util.DateStatics
 import dartzee.game.GameType
 import dartzee.getRows
@@ -11,7 +12,6 @@ import dartzee.helper.retrieveGame
 import dartzee.helper.retrieveParticipant
 import dartzee.screen.ScreenCache
 import dartzee.screen.game.AbstractDartsGameScreen
-import dartzee.shouldBeVisible
 import dartzee.utils.PREFERENCES_BOOLEAN_AI_AUTO_CONTINUE
 import dartzee.utils.PREFERENCES_INT_AI_SPEED
 import dartzee.utils.PreferenceUtil

--- a/src/test/kotlin/e2e/TestMatchE2E.kt
+++ b/src/test/kotlin/e2e/TestMatchE2E.kt
@@ -2,7 +2,7 @@ package e2e
 
 import com.github.alexburlton.swingtest.getChild
 import dartzee.`object`.GameLauncher
-import dartzee.awaitCondition
+import com.github.alexburlton.swingtest.awaitCondition
 import dartzee.core.util.DateStatics
 import dartzee.db.GameEntity
 import dartzee.db.ParticipantEntity


### PR DESCRIPTION
Moved the latest goodies into a new version of the lib, and bumped it to JUnit5. 

This means JUnit4 is no longer on the classpath, so no confusing imports!