### PR TITLE
Parallel test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         run: ./gradlew unitTest --info
     - name: Export test results
-      uses: actions/upload-artifacts@v2
+      uses: actions/upload-artifact@v2
       with:
         name: test-results
         path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/unitTest/**/*.html
@@ -40,7 +40,7 @@ jobs:
         with:
           run: ./gradlew integrationAndE2E --info
       - name: Export test results
-        uses: actions/upload-artifacts@v2
+        uses: actions/upload-artifact@v2
         with:
           name: test-results
           path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/integrationAndE2E/**/*.html

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: CI
 on: push
 jobs:
-  build:
+  unit-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -9,16 +9,28 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Build with Gradle
+    - name: Build & Unit Test
       uses: GabrielBB/xvfb-action@v1.0
-      env:
-        AWS_SYNC: ${{ secrets.AWS_SYNC }}
-        AWS_LOGS: ${{ secrets.AWS_LOGS }}
       with:
-        run: ./gradlew test --info
+        run: ./gradlew unitTest --info
     - name: Export snapshots
       uses: actions/upload-artifact@v2
       if: failure()
       with:
         name: snapshots
         path: /home/runner/**/*.failed.png
+  integration-and-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Integration & E2E
+        uses: GabrielBB/xvfb-action@v1.0
+        env:
+          AWS_SYNC: ${{ secrets.AWS_SYNC }}
+          AWS_LOGS: ${{ secrets.AWS_LOGS }}
+        with:
+          run: ./gradlew integrationAndE2E --info

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,13 +16,13 @@ jobs:
     - name: Export test results
       uses: actions/upload-artifact@v2
       with:
-        name: test-results
+        name: unit-test-results
         path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/unitTest/**/*.html
     - name: Export snapshots
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: snapshots
+        name: failed-snapshots
         path: /home/runner/**/*.failed.png
   integration-and-e2e:
     runs-on: ubuntu-latest
@@ -42,5 +42,5 @@ jobs:
       - name: Export test results
         uses: actions/upload-artifact@v2
         with:
-          name: test-results
+          name: integration-and-e2e-results
           path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/integrationAndE2E/**/*.html

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,11 @@ jobs:
       uses: GabrielBB/xvfb-action@v1.0
       with:
         run: ./gradlew unitTest --info
+    - name: Export test results
+      uses: actions/upload-artifacts@v2
+      with:
+        name: test-results
+        path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/unitTest/**/*.html
     - name: Export snapshots
       uses: actions/upload-artifact@v2
       if: failure()
@@ -34,3 +39,8 @@ jobs:
           AWS_LOGS: ${{ secrets.AWS_LOGS }}
         with:
           run: ./gradlew integrationAndE2E --info
+      - name: Export test results
+        uses: actions/upload-artifacts@v2
+        with:
+          name: test-results
+          path: /home/runner/work/Dartzee/Dartzee/build/reports/tests/integrationAndE2E/**/*.html

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,18 @@ task runDev(type: JavaExec) {
     main 'dartzee.main.DartsMainKt'
 }
 
+task unitTest(type: Test) {
+    useJUnitPlatform {
+        excludeTags "integration", "e2e"
+    }
+}
+
+task integrationAndE2E(type: Test) {
+    useJUnitPlatform {
+        includeTags "integration", "e2e"
+    }
+}
+
 jar {
     manifest {
         attributes 'Main-Class': 'dartzee.main.DartsMainKt'


### PR DESCRIPTION
Speed up CI a bit by splitting out the integration/E2E tests and running them parallel to the rest.

Also export the HTML results.