### PR TITLE
Aggregate rules

### DIFF
--- a/src/main/kotlin/dartzee/bean/DartzeeTotalRuleSelector.kt
+++ b/src/main/kotlin/dartzee/bean/DartzeeTotalRuleSelector.kt
@@ -1,12 +1,13 @@
 package dartzee.bean
 
 import dartzee.core.util.enableChildren
-import dartzee.dartzee.getAllTotalRules
+import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
+import dartzee.dartzee.getAllAggregateRules
 import dartzee.dartzee.total.AbstractDartzeeTotalRule
 
-class DartzeeTotalRuleSelector(desc: String): AbstractDartzeeRuleSelector<AbstractDartzeeTotalRule>(desc)
+class DartzeeTotalRuleSelector(desc: String): AbstractDartzeeRuleSelector<AbstractDartzeeAggregateRule>(desc)
 {
-    override fun getRules() = getAllTotalRules()
+    override fun getRules() = getAllAggregateRules()
     override fun shouldBeEnabled() = cbDesc.isSelected
     override fun isOptional() = true
 

--- a/src/main/kotlin/dartzee/bean/DartzeeTotalRuleSelector.kt
+++ b/src/main/kotlin/dartzee/bean/DartzeeTotalRuleSelector.kt
@@ -3,7 +3,6 @@ package dartzee.bean
 import dartzee.core.util.enableChildren
 import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
 import dartzee.dartzee.getAllAggregateRules
-import dartzee.dartzee.total.AbstractDartzeeTotalRule
 
 class DartzeeTotalRuleSelector(desc: String): AbstractDartzeeRuleSelector<AbstractDartzeeAggregateRule>(desc)
 {

--- a/src/main/kotlin/dartzee/dartzee/AbstractDartzeeRule.kt
+++ b/src/main/kotlin/dartzee/dartzee/AbstractDartzeeRule.kt
@@ -4,10 +4,8 @@ import dartzee.core.util.XmlUtil
 import dartzee.core.util.createRootElement
 import dartzee.core.util.toXmlDoc
 import dartzee.core.util.toXmlString
-import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
-import dartzee.dartzee.aggregate.DartzeeAggregateRuleIncreasing
+import dartzee.dartzee.aggregate.*
 import dartzee.dartzee.dart.*
-import dartzee.dartzee.total.*
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 
@@ -48,7 +46,7 @@ abstract class AbstractDartzeeRule
 
 fun getAllDartRules(): List<AbstractDartzeeDartRule>
 {
-    return mutableListOf(DartzeeDartRuleAny(),
+    return listOf(DartzeeDartRuleAny(),
             DartzeeDartRuleEven(),
             DartzeeDartRuleOdd(),
             DartzeeDartRuleInner(),
@@ -59,7 +57,8 @@ fun getAllDartRules(): List<AbstractDartzeeDartRule>
 }
 fun getAllAggregateRules(): List<AbstractDartzeeAggregateRule>
 {
-    return mutableListOf(DartzeeTotalRuleLessThan(),
+    return listOf(
+        DartzeeTotalRuleLessThan(),
             DartzeeTotalRuleGreaterThan(),
             DartzeeTotalRuleEqualTo(),
             DartzeeTotalRuleEven(),

--- a/src/main/kotlin/dartzee/dartzee/AbstractDartzeeRule.kt
+++ b/src/main/kotlin/dartzee/dartzee/AbstractDartzeeRule.kt
@@ -4,6 +4,8 @@ import dartzee.core.util.XmlUtil
 import dartzee.core.util.createRootElement
 import dartzee.core.util.toXmlDoc
 import dartzee.core.util.toXmlString
+import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
+import dartzee.dartzee.aggregate.DartzeeAggregateRuleIncreasing
 import dartzee.dartzee.dart.*
 import dartzee.dartzee.total.*
 import org.w3c.dom.Document
@@ -55,17 +57,18 @@ fun getAllDartRules(): List<AbstractDartzeeDartRule>
             DartzeeDartRuleScore(),
             DartzeeDartRuleCustom())
 }
-fun getAllTotalRules(): List<AbstractDartzeeTotalRule>
+fun getAllAggregateRules(): List<AbstractDartzeeAggregateRule>
 {
     return mutableListOf(DartzeeTotalRuleLessThan(),
             DartzeeTotalRuleGreaterThan(),
             DartzeeTotalRuleEqualTo(),
             DartzeeTotalRuleEven(),
             DartzeeTotalRuleOdd(),
-            DartzeeTotalRulePrime())
+            DartzeeTotalRulePrime(),
+            DartzeeAggregateRuleIncreasing())
 }
 fun parseDartRule(xmlStr: String) = parseRule(xmlStr, getAllDartRules())
-fun parseTotalRule(xmlStr: String) = parseRule(xmlStr, getAllTotalRules())
+fun parseAggregateRule(xmlStr: String) = parseRule(xmlStr, getAllAggregateRules())
 fun <K: AbstractDartzeeRule> parseRule(xmlStr: String, ruleTemplates: List<K>): K?
 {
     if (xmlStr.isEmpty())

--- a/src/main/kotlin/dartzee/dartzee/DartzeeCalculator.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeCalculator.kt
@@ -5,8 +5,8 @@ import dartzee.`object`.DartboardSegment
 import dartzee.`object`.SegmentType
 import dartzee.core.util.allIndexed
 import dartzee.core.util.getAllPermutations
+import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
 import dartzee.dartzee.dart.AbstractDartzeeDartRule
-import dartzee.dartzee.total.AbstractDartzeeTotalRule
 import dartzee.utils.getAllNonMissSegments
 
 abstract class AbstractDartzeeCalculator
@@ -25,7 +25,7 @@ class DartzeeCalculator: AbstractDartzeeCalculator()
                            rule: DartzeeRuleDto,
                            cachedResults: MutableMap<List<DartboardSegment>, Boolean> = mutableMapOf()): Boolean
     {
-        return isValidCombinationForTotalRule(combination, rule.totalRule)
+        return isValidCombinationForAggregateRule(combination, rule.aggregateRule)
                 && isValidFromMisses(combination, rule)
                 && isValidCombinationForDartRule(combination, rule.getDartRuleList(), rule.inOrder, cachedResults)
     }
@@ -62,15 +62,14 @@ class DartzeeCalculator: AbstractDartzeeCalculator()
         return rule.allowMisses || combination.all { !it.isMiss() }
     }
 
-    private fun isValidCombinationForTotalRule(combination: List<DartboardSegment>, totalRule: AbstractDartzeeTotalRule?): Boolean
+    private fun isValidCombinationForAggregateRule(combination: List<DartboardSegment>, aggregateRule: AbstractDartzeeAggregateRule?): Boolean
     {
-        if (totalRule == null)
+        if (aggregateRule == null)
         {
             return true
         }
 
-        val total = combination.map { it.score * it.getMultiplier() }.sum()
-        return totalRule.isValidTotal(total)
+        return aggregateRule.isValidRound(combination)
     }
     private fun isValidCombinationForDartRule(combination: List<DartboardSegment>,
                                               dartRules: List<AbstractDartzeeDartRule>?,

--- a/src/main/kotlin/dartzee/dartzee/DartzeeRandomiser.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeRandomiser.kt
@@ -17,7 +17,7 @@ object DartzeeRandomiser
         val hasTotalRule = totalRuleBit == 1
 
         val dartRule = if (hasDartRule) makeDartRule() else null
-        val totalRule = if (hasTotalRule) getAllTotalRules().random().also { it.randomise() } else null
+        val totalRule = if (hasTotalRule) getAllAggregateRules().random().also { it.randomise() } else null
 
         val allowMisses = Random.nextInt(5) == 1
 

--- a/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
@@ -74,12 +74,7 @@ data class DartzeeRuleDto(val dart1Rule: AbstractDartzeeDartRule?, val dart2Rule
         val result = ruleParts.joinToString()
         return if (result.isEmpty()) "Anything" else result
     }
-    private fun getTotalDescription(): String
-    {
-        aggregateRule ?: return ""
-
-        return "Total ${aggregateRule.getDescription()}"
-    }
+    private fun getTotalDescription() = aggregateRule?.getDescription() ?: ""
     private fun getDartsDescription(): String
     {
         dart1Rule ?: return ""

--- a/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
@@ -2,14 +2,14 @@ package dartzee.dartzee
 
 import dartzee.`object`.Dart
 import dartzee.`object`.DartboardSegment
+import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
 import dartzee.dartzee.dart.AbstractDartzeeDartRule
-import dartzee.dartzee.total.AbstractDartzeeTotalRule
 import dartzee.db.DartzeeRuleEntity
 import dartzee.utils.InjectedThings.dartzeeCalculator
 import dartzee.utils.sumScore
 
 data class DartzeeRuleDto(val dart1Rule: AbstractDartzeeDartRule?, val dart2Rule: AbstractDartzeeDartRule?, val dart3Rule: AbstractDartzeeDartRule?,
-                          val totalRule: AbstractDartzeeTotalRule?, val inOrder: Boolean, val allowMisses: Boolean)
+                          val aggregateRule: AbstractDartzeeAggregateRule?, val inOrder: Boolean, val allowMisses: Boolean)
 {
     var calculationResult: DartzeeRuleCalculationResult? = null
 
@@ -76,9 +76,9 @@ data class DartzeeRuleDto(val dart1Rule: AbstractDartzeeDartRule?, val dart2Rule
     }
     private fun getTotalDescription(): String
     {
-        totalRule ?: return ""
+        aggregateRule ?: return ""
 
-        return "Total ${totalRule.getDescription()}"
+        return "Total ${aggregateRule.getDescription()}"
     }
     private fun getDartsDescription(): String
     {
@@ -119,7 +119,7 @@ data class DartzeeRuleDto(val dart1Rule: AbstractDartzeeDartRule?, val dart2Rule
         entity.dart1Rule = dart1Rule?.toDbString() ?: ""
         entity.dart2Rule = dart2Rule?.toDbString() ?: ""
         entity.dart3Rule = dart3Rule?.toDbString() ?: ""
-        entity.totalRule = totalRule?.toDbString() ?: ""
+        entity.aggregateRule = aggregateRule?.toDbString() ?: ""
         entity.allowMisses = allowMisses
         entity.inOrder = inOrder
         entity.entityName = entityName

--- a/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeAggregateRule.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeAggregateRule.kt
@@ -1,0 +1,9 @@
+package dartzee.dartzee.aggregate
+
+import dartzee.`object`.DartboardSegment
+import dartzee.dartzee.AbstractDartzeeRule
+
+abstract class AbstractDartzeeAggregateRule: AbstractDartzeeRule()
+{
+    abstract fun isValidRound(segments: List<DartboardSegment>): Boolean
+}

--- a/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeRuleTotalSize.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeRuleTotalSize.kt
@@ -1,4 +1,4 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 import dartzee.core.util.getAttributeInt
 import dartzee.dartzee.IDartzeeRuleConfigurable

--- a/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeTotalRule.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeTotalRule.kt
@@ -1,7 +1,6 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 import dartzee.`object`.DartboardSegment
-import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
 
 abstract class AbstractDartzeeTotalRule: AbstractDartzeeAggregateRule()
 {

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleIncreasing.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleIncreasing.kt
@@ -1,0 +1,14 @@
+package dartzee.dartzee.aggregate
+
+import dartzee.`object`.DartboardSegment
+
+class DartzeeAggregateRuleIncreasing: AbstractDartzeeAggregateRule()
+{
+    override fun isValidRound(segments: List<DartboardSegment>): Boolean
+    {
+        val scores = segments.map { it.getTotal() }
+        return scores.distinct().size == 3 && scores.sorted() == scores
+    }
+
+    override fun getRuleIdentifier() = "DartsIncreasing"
+}

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleIncreasing.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleIncreasing.kt
@@ -11,4 +11,5 @@ class DartzeeAggregateRuleIncreasing: AbstractDartzeeAggregateRule()
     }
 
     override fun getRuleIdentifier() = "DartsIncreasing"
+    override fun getDescription() = "Darts are increasing"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleIncreasing.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleIncreasing.kt
@@ -11,5 +11,5 @@ class DartzeeAggregateRuleIncreasing: AbstractDartzeeAggregateRule()
     }
 
     override fun getRuleIdentifier() = "DartsIncreasing"
-    override fun getDescription() = "Darts are increasing"
+    override fun toString() = "Darts are increasing"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEqualTo.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEqualTo.kt
@@ -8,5 +8,5 @@ class DartzeeTotalRuleEqualTo: AbstractDartzeeRuleTotalSize()
 
     override fun toString() = "Total equal to"
 
-    override fun getDescription() = "= $target"
+    override fun getDescription() = "Total = $target"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEqualTo.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEqualTo.kt
@@ -1,4 +1,4 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 class DartzeeTotalRuleEqualTo: AbstractDartzeeRuleTotalSize()
 {
@@ -6,7 +6,7 @@ class DartzeeTotalRuleEqualTo: AbstractDartzeeRuleTotalSize()
 
     override fun isValidTotal(total: Int) = total == target
 
-    override fun toString() = "Equal to"
+    override fun toString() = "Total equal to"
 
     override fun getDescription() = "= $target"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEven.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEven.kt
@@ -1,9 +1,9 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 class DartzeeTotalRuleEven: AbstractDartzeeTotalRule()
 {
     override fun getRuleIdentifier() = "Even"
 
     override fun isValidTotal(total: Int) = (total % 2) == 0
-    override fun getDescription() = "is even"
+    override fun getDescription() = "Total is even"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEven.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleEven.kt
@@ -5,5 +5,5 @@ class DartzeeTotalRuleEven: AbstractDartzeeTotalRule()
     override fun getRuleIdentifier() = "Even"
 
     override fun isValidTotal(total: Int) = (total % 2) == 0
-    override fun getDescription() = "Total is even"
+    override fun toString() = "Total is even"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleGreaterThan.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleGreaterThan.kt
@@ -1,4 +1,4 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 class DartzeeTotalRuleGreaterThan: AbstractDartzeeRuleTotalSize()
 {
@@ -6,7 +6,7 @@ class DartzeeTotalRuleGreaterThan: AbstractDartzeeRuleTotalSize()
 
     override fun isValidTotal(total: Int) = total > target
 
-    override fun toString() = "Greater than"
+    override fun toString() = "Total greater than"
 
     override fun getDescription() = "> $target"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleGreaterThan.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleGreaterThan.kt
@@ -8,5 +8,5 @@ class DartzeeTotalRuleGreaterThan: AbstractDartzeeRuleTotalSize()
 
     override fun toString() = "Total greater than"
 
-    override fun getDescription() = "> $target"
+    override fun getDescription() = "Total > $target"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleLessThan.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleLessThan.kt
@@ -1,4 +1,4 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 class DartzeeTotalRuleLessThan: AbstractDartzeeRuleTotalSize()
 {
@@ -6,7 +6,7 @@ class DartzeeTotalRuleLessThan: AbstractDartzeeRuleTotalSize()
 
     override fun isValidTotal(total: Int) = total < target
 
-    override fun toString() = "Less than"
+    override fun toString() = "Total less than"
 
     override fun getDescription() = "< $target"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleLessThan.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleLessThan.kt
@@ -8,5 +8,5 @@ class DartzeeTotalRuleLessThan: AbstractDartzeeRuleTotalSize()
 
     override fun toString() = "Total less than"
 
-    override fun getDescription() = "< $target"
+    override fun getDescription() = "Total < $target"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleOdd.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleOdd.kt
@@ -1,9 +1,9 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 class DartzeeTotalRuleOdd: AbstractDartzeeTotalRule()
 {
     override fun getRuleIdentifier() = "Odd"
 
     override fun isValidTotal(total: Int) = (total % 2) != 0
-    override fun getDescription() = "is odd"
+    override fun getDescription() = "Total is odd"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleOdd.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRuleOdd.kt
@@ -5,5 +5,5 @@ class DartzeeTotalRuleOdd: AbstractDartzeeTotalRule()
     override fun getRuleIdentifier() = "Odd"
 
     override fun isValidTotal(total: Int) = (total % 2) != 0
-    override fun getDescription() = "Total is odd"
+    override fun toString() = "Total is odd"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRulePrime.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRulePrime.kt
@@ -7,5 +7,5 @@ class DartzeeTotalRulePrime: AbstractDartzeeTotalRule()
     override fun getRuleIdentifier() = "Prime"
 
     override fun isValidTotal(total: Int) = Primes.isPrime(total)
-    override fun getDescription() = "Total is prime"
+    override fun toString() = "Total is prime"
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRulePrime.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeTotalRulePrime.kt
@@ -1,4 +1,4 @@
-package dartzee.dartzee.total
+package dartzee.dartzee.aggregate
 
 import org.apache.commons.math3.primes.Primes
 
@@ -7,5 +7,5 @@ class DartzeeTotalRulePrime: AbstractDartzeeTotalRule()
     override fun getRuleIdentifier() = "Prime"
 
     override fun isValidTotal(total: Int) = Primes.isPrime(total)
-    override fun getDescription() = "is prime"
+    override fun getDescription() = "Total is prime"
 }

--- a/src/main/kotlin/dartzee/dartzee/total/AbstractDartzeeTotalRule.kt
+++ b/src/main/kotlin/dartzee/dartzee/total/AbstractDartzeeTotalRule.kt
@@ -1,8 +1,10 @@
 package dartzee.dartzee.total
 
-import dartzee.dartzee.AbstractDartzeeRule
+import dartzee.`object`.DartboardSegment
+import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
 
-abstract class AbstractDartzeeTotalRule: AbstractDartzeeRule()
+abstract class AbstractDartzeeTotalRule: AbstractDartzeeAggregateRule()
 {
+    override fun isValidRound(segments: List<DartboardSegment>) = isValidTotal(segments.sumBy { it.getTotal() })
     abstract fun isValidTotal(total: Int): Boolean
 }

--- a/src/main/kotlin/dartzee/db/DartzeeRuleEntity.kt
+++ b/src/main/kotlin/dartzee/db/DartzeeRuleEntity.kt
@@ -3,7 +3,7 @@ package dartzee.db
 import dartzee.dartzee.DartzeeRuleCalculationResult
 import dartzee.dartzee.DartzeeRuleDto
 import dartzee.dartzee.parseDartRule
-import dartzee.dartzee.parseTotalRule
+import dartzee.dartzee.parseAggregateRule
 import dartzee.utils.Database
 import dartzee.utils.InjectedThings.mainDatabase
 
@@ -14,7 +14,7 @@ class DartzeeRuleEntity(database: Database = mainDatabase): AbstractEntity<Dartz
     var dart1Rule = ""
     var dart2Rule = ""
     var dart3Rule = ""
-    var totalRule = ""
+    var aggregateRule = ""
     var inOrder = false
     var allowMisses = false
     var ordinal = -1
@@ -29,7 +29,7 @@ class DartzeeRuleEntity(database: Database = mainDatabase): AbstractEntity<Dartz
                 + "Dart1Rule VARCHAR(32000) NOT NULL, "
                 + "Dart2Rule VARCHAR(32000) NOT NULL, "
                 + "Dart3Rule VARCHAR(32000) NOT NULL, "
-                + "TotalRule VARCHAR(255) NOT NULL, "
+                + "AggregateRule VARCHAR(255) NOT NULL, "
                 + "InOrder BOOLEAN NOT NULL, "
                 + "AllowMisses BOOLEAN NOT NULL, "
                 + "Ordinal INT NOT NULL, "
@@ -41,7 +41,7 @@ class DartzeeRuleEntity(database: Database = mainDatabase): AbstractEntity<Dartz
         val rule1 = parseDartRule(dart1Rule)
         val rule2 = parseDartRule(dart2Rule)
         val rule3 = parseDartRule(dart3Rule)
-        val total = parseTotalRule(totalRule)
+        val total = parseAggregateRule(aggregateRule)
 
         val dto = DartzeeRuleDto(rule1, rule2, rule3, total, inOrder, allowMisses)
         if (includeCalculationResult)

--- a/src/main/kotlin/dartzee/screen/dartzee/DartzeeRuleCreationDialog.kt
+++ b/src/main/kotlin/dartzee/screen/dartzee/DartzeeRuleCreationDialog.kt
@@ -136,7 +136,7 @@ class DartzeeRuleCreationDialog(private val verificationPanel: DartzeeRuleVerifi
             dartThreeSelector.populate(rule.dart3Rule!!)
         }
 
-        totalSelector.populate(rule.totalRule)
+        totalSelector.populate(rule.aggregateRule)
 
         cbAllowMisses.isSelected = rule.allowMisses
 

--- a/src/main/kotlin/dartzee/screen/dartzee/DartzeeRuleCreationDialog.kt
+++ b/src/main/kotlin/dartzee/screen/dartzee/DartzeeRuleCreationDialog.kt
@@ -38,7 +38,7 @@ class DartzeeRuleCreationDialog(private val verificationPanel: DartzeeRuleVerifi
     private val panelTotal = JPanel()
     private val panelAllowMisses = JPanel()
     val cbAllowMisses = JCheckBox("Allow misses")
-    val totalSelector = DartzeeTotalRuleSelector("Total")
+    val aggregateSelector = DartzeeTotalRuleSelector("Other")
     private val panelRuleName = JPanel()
     val tfName = JTextField()
     val btnRandom = JButton()
@@ -73,7 +73,7 @@ class DartzeeRuleCreationDialog(private val verificationPanel: DartzeeRuleVerifi
 
         panelTotal.layout = MigLayout("", "[]", "[]")
 
-        panelTotal.add(totalSelector, "cell 0 0")
+        panelTotal.add(aggregateSelector, "cell 0 0")
 
         panelAllowMisses.layout = MigLayout("", "[]", "[]")
         panelAllowMisses.add(cbAllowMisses, "cell 0 0")
@@ -96,7 +96,7 @@ class DartzeeRuleCreationDialog(private val verificationPanel: DartzeeRuleVerifi
         dartTwoSelector.addActionListener(this)
         dartThreeSelector.addActionListener(this)
         targetSelector.addActionListener(this)
-        totalSelector.addActionListener(this)
+        aggregateSelector.addActionListener(this)
         cbInOrder.addActionListener(this)
         cbAllowMisses.addActionListener(this)
         btnRandom.addActionListener(this)
@@ -136,7 +136,7 @@ class DartzeeRuleCreationDialog(private val verificationPanel: DartzeeRuleVerifi
             dartThreeSelector.populate(rule.dart3Rule!!)
         }
 
-        totalSelector.populate(rule.aggregateRule)
+        aggregateSelector.populate(rule.aggregateRule)
 
         cbAllowMisses.isSelected = rule.allowMisses
 
@@ -189,7 +189,7 @@ class DartzeeRuleCreationDialog(private val verificationPanel: DartzeeRuleVerifi
 
     fun constructRuleFromComponents(): DartzeeRuleDto
     {
-        val totalRule = if (totalSelector.isEnabled) totalSelector.getSelection() else null
+        val totalRule = if (aggregateSelector.isEnabled) aggregateSelector.getSelection() else null
 
         return if (rdbtnAllDarts.isSelected)
         {

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -20,7 +20,7 @@ import kotlin.system.exitProcess
  */
 object DartsDatabaseUtil
 {
-    const val DATABASE_VERSION = 18
+    const val DATABASE_VERSION = 19
     const val DATABASE_NAME = "Darts"
     const val OTHER_DATABASE_NAME = "DartsOther" //Tmp name used for restore from backup and/or sync
 

--- a/src/main/kotlin/dartzee/utils/DatabaseMigrations.kt
+++ b/src/main/kotlin/dartzee/utils/DatabaseMigrations.kt
@@ -29,6 +29,9 @@ object DatabaseMigrations
             ),
             17 to listOf(
                 { db -> convertDartzeeCalculationResults(db) }
+            ),
+            18 to listOf(
+                { db -> runScript(db, 19, "1. DartzeeRule.sql") }
             )
         )
     }

--- a/src/main/resources/sql/v19/1. DartzeeRule.sql
+++ b/src/main/resources/sql/v19/1. DartzeeRule.sql
@@ -1,0 +1,1 @@
+RENAME COLUMN DartzeeRule.TotalRule TO AggregateRule

--- a/src/test/kotlin/dartzee/bean/TestDartzeeTotalRuleSelector.kt
+++ b/src/test/kotlin/dartzee/bean/TestDartzeeTotalRuleSelector.kt
@@ -1,7 +1,7 @@
 package dartzee.bean
 
 import dartzee.dartzee.getAllAggregateRules
-import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEqualTo
 import dartzee.helper.AbstractTest
 import io.kotlintest.matchers.collections.shouldContain
 import io.kotlintest.matchers.collections.shouldNotContain

--- a/src/test/kotlin/dartzee/bean/TestDartzeeTotalRuleSelector.kt
+++ b/src/test/kotlin/dartzee/bean/TestDartzeeTotalRuleSelector.kt
@@ -1,6 +1,6 @@
 package dartzee.bean
 
-import dartzee.dartzee.getAllTotalRules
+import dartzee.dartzee.getAllAggregateRules
 import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
 import dartzee.helper.AbstractTest
 import io.kotlintest.matchers.collections.shouldContain
@@ -14,7 +14,7 @@ class TestDartzeeTotalRuleSelector : AbstractTest()
     fun `Should initialise with all the total rules`()
     {
         val selector = DartzeeTotalRuleSelector("")
-        selector.getRules().size shouldBe getAllTotalRules().size
+        selector.getRules().size shouldBe getAllAggregateRules().size
     }
 
     @Test

--- a/src/test/kotlin/dartzee/dartzee/AbstractDartzeeRuleTest.kt
+++ b/src/test/kotlin/dartzee/dartzee/AbstractDartzeeRuleTest.kt
@@ -44,7 +44,7 @@ abstract class AbstractDartzeeRuleTest<E: AbstractDartzeeRule>: AbstractTest()
         }
         else
         {
-            getAllTotalRules()
+            getAllAggregateRules()
         }
     }
 }

--- a/src/test/kotlin/dartzee/dartzee/TestDartzeeCalculator.kt
+++ b/src/test/kotlin/dartzee/dartzee/TestDartzeeCalculator.kt
@@ -8,9 +8,9 @@ import dartzee.dartzee.dart.DartzeeDartRuleAny
 import dartzee.dartzee.dart.DartzeeDartRuleEven
 import dartzee.dartzee.dart.DartzeeDartRuleOdd
 import dartzee.dartzee.dart.DartzeeDartRuleOuter
-import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
-import dartzee.dartzee.total.DartzeeTotalRuleEven
-import dartzee.dartzee.total.DartzeeTotalRuleLessThan
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEqualTo
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEven
+import dartzee.dartzee.aggregate.DartzeeTotalRuleLessThan
 import dartzee.helper.*
 import dartzee.utils.getAllPossibleSegments
 import io.kotlintest.matchers.collections.shouldBeEmpty
@@ -305,7 +305,7 @@ class TestValidCombinations: AbstractTest()
     @Test
     fun `should test for just total rules`()
     {
-        val rule = makeDartzeeRuleDto(totalRule = makeTotalScoreRule<DartzeeTotalRuleEqualTo>(50))
+        val rule = makeDartzeeRuleDto(aggregateRule = makeTotalScoreRule<DartzeeTotalRuleEqualTo>(50))
 
         DartzeeCalculator().isValidCombination(listOf(singleTwenty, singleTwenty, singleTen), rule) shouldBe true
         DartzeeCalculator().isValidCombination(listOf(outerBull, singleTwenty, singleFive), rule) shouldBe true

--- a/src/test/kotlin/dartzee/dartzee/TestDartzeeRuleDto.kt
+++ b/src/test/kotlin/dartzee/dartzee/TestDartzeeRuleDto.kt
@@ -201,7 +201,7 @@ class TestDartzeeRuleDto: AbstractTest()
         dao.dart1Rule shouldBe DartzeeDartRuleEven().toDbString()
         dao.dart2Rule shouldBe DartzeeDartRuleOdd().toDbString()
         dao.dart3Rule shouldBe DartzeeDartRuleInner().toDbString()
-        dao.totalRule shouldBe DartzeeTotalRulePrime().toDbString()
+        dao.aggregateRule shouldBe DartzeeTotalRulePrime().toDbString()
     }
 
     private val dartsForTotal = listOf(makeDart(20, 1), makeDart(20, 1), makeDart(5, 2))

--- a/src/test/kotlin/dartzee/dartzee/TestDartzeeRuleDto.kt
+++ b/src/test/kotlin/dartzee/dartzee/TestDartzeeRuleDto.kt
@@ -1,8 +1,8 @@
 package dartzee.dartzee
 
 import dartzee.dartzee.dart.*
-import dartzee.dartzee.total.DartzeeTotalRuleGreaterThan
-import dartzee.dartzee.total.DartzeeTotalRulePrime
+import dartzee.dartzee.aggregate.DartzeeTotalRuleGreaterThan
+import dartzee.dartzee.aggregate.DartzeeTotalRulePrime
 import dartzee.doubleNineteen
 import dartzee.doubleTwenty
 import dartzee.helper.*
@@ -37,7 +37,7 @@ class TestDartzeeRuleDto: AbstractTest()
     @Test
     fun `Dart rule list should be null if no dart rules have been set`()
     {
-        val rule = makeDartzeeRuleDto(totalRule = DartzeeTotalRulePrime())
+        val rule = makeDartzeeRuleDto(aggregateRule = DartzeeTotalRulePrime())
 
         rule.getDartRuleList() shouldBe null
     }
@@ -66,10 +66,10 @@ class TestDartzeeRuleDto: AbstractTest()
     @Test
     fun `Should describe total rules correctly`()
     {
-        val rule = makeDartzeeRuleDto(totalRule = DartzeeTotalRulePrime())
+        val rule = makeDartzeeRuleDto(aggregateRule = DartzeeTotalRulePrime())
         rule.generateRuleDescription() shouldBe "Total is prime"
 
-        val rule2 = makeDartzeeRuleDto(totalRule = DartzeeTotalRuleGreaterThan())
+        val rule2 = makeDartzeeRuleDto(aggregateRule = DartzeeTotalRuleGreaterThan())
         rule2.generateRuleDescription() shouldBe "Total > 20"
     }
 
@@ -151,7 +151,7 @@ class TestDartzeeRuleDto: AbstractTest()
     {
         val rule = makeDartzeeRuleDto(
             DartzeeDartRuleEven(),
-            totalRule = DartzeeTotalRuleGreaterThan()
+            aggregateRule = DartzeeTotalRuleGreaterThan()
         )
         rule.generateRuleDescription() shouldBe "Score Evens, Total > 20"
     }
@@ -161,7 +161,7 @@ class TestDartzeeRuleDto: AbstractTest()
     {
         val validSegments = listOf(doubleNineteen, doubleTwenty)
 
-        val rule = makeDartzeeRuleDto(totalRule = DartzeeTotalRulePrime())
+        val rule = makeDartzeeRuleDto(aggregateRule = DartzeeTotalRulePrime())
         rule.getScoringSegments(validSegments).shouldContainExactly(doubleNineteen, doubleTwenty)
     }
 

--- a/src/test/kotlin/dartzee/dartzee/TestDartzeeRules.kt
+++ b/src/test/kotlin/dartzee/dartzee/TestDartzeeRules.kt
@@ -21,7 +21,7 @@ class TestDartzeeRules: AbstractTest()
     @Test
     fun `no total rules should have overlapping identifiers`()
     {
-        val rules = getAllTotalRules()
+        val rules = getAllAggregateRules()
 
         val nameCount = rules.map{ it.getRuleIdentifier() }.distinct().count()
         nameCount shouldBe rules.size

--- a/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeAggregateRuleIncreasing.kt
+++ b/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeAggregateRuleIncreasing.kt
@@ -1,0 +1,36 @@
+package dartzee.dartzee.aggregate
+
+import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.helper.double
+import dartzee.helper.outerSingle
+import dartzee.helper.treble
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+
+class TestDartzeeAggregateRuleIncreasing: AbstractDartzeeRuleTest<DartzeeAggregateRuleIncreasing>()
+{
+    override fun factory() = DartzeeAggregateRuleIncreasing()
+
+    @Test
+    fun `Should be valid if scores are increasing`()
+    {
+        val rule = factory()
+        rule.isValidRound(listOf(outerSingle(5), outerSingle(10), outerSingle(15))) shouldBe true
+        rule.isValidRound(listOf(outerSingle(10), double(6), treble(5))) shouldBe true
+    }
+
+    @Test
+    fun `Should not be valid if two the same`()
+    {
+        val rule = factory()
+        rule.isValidRound(listOf(outerSingle(5), outerSingle(10), outerSingle(10))) shouldBe false
+        rule.isValidRound(listOf(outerSingle(12), double(6), treble(6))) shouldBe false
+    }
+
+    @Test
+    fun `Should not be valid if not increasing`()
+    {
+        val rule = factory()
+        rule.isValidRound(listOf(outerSingle(5), outerSingle(15), outerSingle(10))) shouldBe false
+    }
+}

--- a/src/test/kotlin/dartzee/dartzee/total/TestAbstractDartzeeRuleTotalSize.kt
+++ b/src/test/kotlin/dartzee/dartzee/total/TestAbstractDartzeeRuleTotalSize.kt
@@ -1,5 +1,6 @@
 package dartzee.dartzee.total
 
+import dartzee.dartzee.aggregate.AbstractDartzeeRuleTotalSize
 import dartzee.helper.AbstractTest
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow

--- a/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleEqualTo.kt
+++ b/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleEqualTo.kt
@@ -1,6 +1,7 @@
 package dartzee.dartzee.total
 
 import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEqualTo
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleEven.kt
+++ b/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleEven.kt
@@ -1,6 +1,7 @@
 package dartzee.dartzee.total
 
 import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEven
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleGreaterThan.kt
+++ b/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleGreaterThan.kt
@@ -1,6 +1,7 @@
 package dartzee.dartzee.total
 
 import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.dartzee.aggregate.DartzeeTotalRuleGreaterThan
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleLessThan.kt
+++ b/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleLessThan.kt
@@ -1,6 +1,7 @@
 package dartzee.dartzee.total
 
 import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.dartzee.aggregate.DartzeeTotalRuleLessThan
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleOdd.kt
+++ b/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRuleOdd.kt
@@ -1,6 +1,7 @@
 package dartzee.dartzee.total
 
 import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.dartzee.aggregate.DartzeeTotalRuleOdd
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRulePrime.kt
+++ b/src/test/kotlin/dartzee/dartzee/total/TestDartzeeTotalRulePrime.kt
@@ -1,6 +1,7 @@
 package dartzee.dartzee.total
 
 import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.dartzee.aggregate.DartzeeTotalRulePrime
 import io.kotlintest.shouldBe
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
@@ -4,7 +4,7 @@ import dartzee.dartzee.dart.DartzeeDartRuleCustom
 import dartzee.dartzee.dart.DartzeeDartRuleEven
 import dartzee.dartzee.dart.DartzeeDartRuleOdd
 import dartzee.dartzee.dart.DartzeeDartRuleOuter
-import dartzee.dartzee.total.DartzeeTotalRuleEven
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEven
 import dartzee.doubleNineteen
 import dartzee.helper.insertDartzeeRule
 import dartzee.helper.insertDartzeeTemplate

--- a/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
+++ b/src/test/kotlin/dartzee/db/TestDartzeeRuleEntity.kt
@@ -68,7 +68,7 @@ class TestDartzeeRuleEntity: AbstractEntityTest<DartzeeRuleEntity>()
         entity.dart1Rule = "<Even />"
         entity.dart2Rule = "<Odd />"
         entity.dart3Rule = "<Outer />"
-        entity.totalRule = "<Even />"
+        entity.aggregateRule = "<Even />"
         entity.allowMisses = true
         entity.inOrder = false
 
@@ -80,7 +80,7 @@ class TestDartzeeRuleEntity: AbstractEntityTest<DartzeeRuleEntity>()
         dto.dart1Rule!!.shouldBeInstanceOf<DartzeeDartRuleEven>()
         dto.dart2Rule!!.shouldBeInstanceOf<DartzeeDartRuleOdd>()
         dto.dart3Rule!!.shouldBeInstanceOf<DartzeeDartRuleOuter>()
-        dto.totalRule!!.shouldBeInstanceOf<DartzeeTotalRuleEven>()
+        dto.aggregateRule!!.shouldBeInstanceOf<DartzeeTotalRuleEven>()
         dto.allowMisses shouldBe true
         dto.inOrder shouldBe false
 
@@ -95,7 +95,7 @@ class TestDartzeeRuleEntity: AbstractEntityTest<DartzeeRuleEntity>()
         entity.dart1Rule = "<Even />"
         entity.dart2Rule = "<Odd />"
         entity.dart3Rule = "<Outer />"
-        entity.totalRule = "<Even />"
+        entity.aggregateRule = "<Even />"
         entity.allowMisses = true
         entity.inOrder = false
 
@@ -107,7 +107,7 @@ class TestDartzeeRuleEntity: AbstractEntityTest<DartzeeRuleEntity>()
         dto.dart1Rule!!.shouldBeInstanceOf<DartzeeDartRuleEven>()
         dto.dart2Rule!!.shouldBeInstanceOf<DartzeeDartRuleOdd>()
         dto.dart3Rule!!.shouldBeInstanceOf<DartzeeDartRuleOuter>()
-        dto.totalRule!!.shouldBeInstanceOf<DartzeeTotalRuleEven>()
+        dto.aggregateRule!!.shouldBeInstanceOf<DartzeeTotalRuleEven>()
         dto.allowMisses shouldBe true
         dto.inOrder shouldBe false
 

--- a/src/test/kotlin/dartzee/helper/DartboardSegmentFactory.kt
+++ b/src/test/kotlin/dartzee/helper/DartboardSegmentFactory.kt
@@ -1,0 +1,8 @@
+package dartzee.helper
+
+import dartzee.`object`.DartboardSegment
+import dartzee.`object`.SegmentType
+
+fun outerSingle(score: Int) = DartboardSegment(SegmentType.OUTER_SINGLE, score)
+fun double(score: Int) = DartboardSegment(SegmentType.DOUBLE, score)
+fun treble(score: Int) = DartboardSegment(SegmentType.TREBLE, score)

--- a/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
+++ b/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
@@ -6,10 +6,10 @@ import dartzee.`object`.SegmentType
 import dartzee.dartzee.DartzeeRoundResult
 import dartzee.dartzee.DartzeeRuleCalculationResult
 import dartzee.dartzee.DartzeeRuleDto
+import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
 import dartzee.dartzee.dart.*
-import dartzee.dartzee.getAllTotalRules
+import dartzee.dartzee.getAllAggregateRules
 import dartzee.dartzee.total.AbstractDartzeeRuleTotalSize
-import dartzee.dartzee.total.AbstractDartzeeTotalRule
 import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
 import dartzee.db.DartzeeRoundResultEntity
 import dartzee.db.ParticipantEntity
@@ -39,7 +39,7 @@ val allTwenties = makeDartzeeRuleDto(makeScoreRule(20), makeScoreRule(20), makeS
 fun makeDartzeeRuleDto(dart1Rule: AbstractDartzeeDartRule? = null,
                        dart2Rule: AbstractDartzeeDartRule? = null,
                        dart3Rule: AbstractDartzeeDartRule? = null,
-                       totalRule: AbstractDartzeeTotalRule? = null,
+                       totalRule: AbstractDartzeeAggregateRule? = null,
                        inOrder: Boolean = false,
                        allowMisses: Boolean = false,
                        calculationResult: DartzeeRuleCalculationResult = makeDartzeeRuleCalculationResult()): DartzeeRuleDto
@@ -75,7 +75,7 @@ fun makeColourRule(red: Boolean = false, green: Boolean = false, black: Boolean 
     return rule
 }
 
-inline fun <reified T: AbstractDartzeeRuleTotalSize> makeTotalScoreRule(score: Int) = getAllTotalRules().find { it is T }.also { (it as T).target = score }
+inline fun <reified T: AbstractDartzeeRuleTotalSize> makeTotalScoreRule(score: Int) = getAllAggregateRules().find { it is T }.also { (it as T).target = score }
 
 fun getOuterSegments() = getAllPossibleSegments().filter { it.type == SegmentType.DOUBLE || it.type == SegmentType.OUTER_SINGLE }.filter { it.score != 25 }
 fun getInnerSegments() = getAllPossibleSegments().filter { (it.score == 25 && !it.isMiss()) || it.type == SegmentType.TREBLE || it.type == SegmentType.INNER_SINGLE }

--- a/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
+++ b/src/test/kotlin/dartzee/helper/DartzeeTestUtils.kt
@@ -9,8 +9,8 @@ import dartzee.dartzee.DartzeeRuleDto
 import dartzee.dartzee.aggregate.AbstractDartzeeAggregateRule
 import dartzee.dartzee.dart.*
 import dartzee.dartzee.getAllAggregateRules
-import dartzee.dartzee.total.AbstractDartzeeRuleTotalSize
-import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
+import dartzee.dartzee.aggregate.AbstractDartzeeRuleTotalSize
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEqualTo
 import dartzee.db.DartzeeRoundResultEntity
 import dartzee.db.ParticipantEntity
 import dartzee.game.state.DartzeePlayerState
@@ -29,7 +29,7 @@ val innerOuterInner = makeDartzeeRuleDto(DartzeeDartRuleInner(), DartzeeDartRule
         inOrder = true,
         calculationResult = makeDartzeeRuleCalculationResult(getInnerSegments()))
 
-val totalIsFifty = makeDartzeeRuleDto(totalRule = makeTotalScoreRule<DartzeeTotalRuleEqualTo>(50),
+val totalIsFifty = makeDartzeeRuleDto(aggregateRule = makeTotalScoreRule<DartzeeTotalRuleEqualTo>(50),
         calculationResult = makeDartzeeRuleCalculationResult(getAllPossibleSegments().filter { !it.isMiss() }))
 
 val allTwenties = makeDartzeeRuleDto(makeScoreRule(20), makeScoreRule(20), makeScoreRule(20),
@@ -39,12 +39,12 @@ val allTwenties = makeDartzeeRuleDto(makeScoreRule(20), makeScoreRule(20), makeS
 fun makeDartzeeRuleDto(dart1Rule: AbstractDartzeeDartRule? = null,
                        dart2Rule: AbstractDartzeeDartRule? = null,
                        dart3Rule: AbstractDartzeeDartRule? = null,
-                       totalRule: AbstractDartzeeAggregateRule? = null,
+                       aggregateRule: AbstractDartzeeAggregateRule? = null,
                        inOrder: Boolean = false,
                        allowMisses: Boolean = false,
                        calculationResult: DartzeeRuleCalculationResult = makeDartzeeRuleCalculationResult()): DartzeeRuleDto
 {
-    val rule = DartzeeRuleDto(dart1Rule, dart2Rule, dart3Rule, totalRule, inOrder, allowMisses)
+    val rule = DartzeeRuleDto(dart1Rule, dart2Rule, dart3Rule, aggregateRule, inOrder, allowMisses)
     rule.calculationResult = calculationResult
     return rule
 }

--- a/src/test/kotlin/dartzee/screen/TestGameSetupScreen.kt
+++ b/src/test/kotlin/dartzee/screen/TestGameSetupScreen.kt
@@ -7,7 +7,7 @@ import dartzee.bean.GameParamFilterPanelX01
 import dartzee.bean.getAllPlayers
 import dartzee.dartzee.dart.DartzeeDartRuleEven
 import dartzee.dartzee.dart.DartzeeDartRuleOdd
-import dartzee.dartzee.total.DartzeeTotalRulePrime
+import dartzee.dartzee.aggregate.DartzeeTotalRulePrime
 import dartzee.db.DARTZEE_TEMPLATE
 import dartzee.db.DartsMatchEntity
 import dartzee.game.GameType
@@ -154,7 +154,7 @@ class TestGameSetupScreen: AbstractTest()
         val templateId = insertDartzeeTemplate().rowId
 
         val ruleOne = makeDartzeeRuleDto(DartzeeDartRuleEven(), DartzeeDartRuleOdd(), DartzeeDartRuleEven())
-        val ruleTwo = makeDartzeeRuleDto(totalRule = DartzeeTotalRulePrime())
+        val ruleTwo = makeDartzeeRuleDto(aggregateRule = DartzeeTotalRulePrime())
 
         ruleOne.toEntity(1, DARTZEE_TEMPLATE, templateId).saveToDatabase()
         ruleTwo.toEntity(2, DARTZEE_TEMPLATE, templateId).saveToDatabase()

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
@@ -9,9 +9,9 @@ import dartzee.core.helper.makeActionEvent
 import dartzee.core.util.getAllChildComponentsForType
 import dartzee.dartzee.DartzeeCalculator
 import dartzee.dartzee.dart.*
-import dartzee.dartzee.total.DartzeeTotalRuleEqualTo
-import dartzee.dartzee.total.DartzeeTotalRuleOdd
-import dartzee.dartzee.total.DartzeeTotalRulePrime
+import dartzee.dartzee.aggregate.DartzeeTotalRuleEqualTo
+import dartzee.dartzee.aggregate.DartzeeTotalRuleOdd
+import dartzee.dartzee.aggregate.DartzeeTotalRulePrime
 import dartzee.helper.*
 import dartzee.utils.InjectedThings
 import io.kotlintest.matchers.collections.shouldBeEmpty
@@ -104,17 +104,17 @@ class TestDartzeeRuleAmendment: AbstractTest()
         val dlg = DartzeeRuleCreationDialog()
         dlg.amendRule(makeDartzeeRuleDto())
 
-        dlg.totalSelector.cbDesc.isSelected shouldBe false
+        dlg.aggregateSelector.cbDesc.isSelected shouldBe false
     }
 
     @Test
     fun `Should populate a total rule correctly`()
     {
         val dlg = DartzeeRuleCreationDialog()
-        dlg.amendRule(makeDartzeeRuleDto(totalRule = makeTotalScoreRule<DartzeeTotalRuleEqualTo>(48)))
+        dlg.amendRule(makeDartzeeRuleDto(aggregateRule = makeTotalScoreRule<DartzeeTotalRuleEqualTo>(48)))
 
-        dlg.totalSelector.cbDesc.isSelected shouldBe true
-        val totalRule = dlg.totalSelector.getSelection() as DartzeeTotalRuleEqualTo
+        dlg.aggregateSelector.cbDesc.isSelected shouldBe true
+        val totalRule = dlg.aggregateSelector.getSelection() as DartzeeTotalRuleEqualTo
         totalRule.target shouldBe 48
     }
 
@@ -240,8 +240,8 @@ class TestDartzeeRuleCreationDialogValidation: AbstractTest()
             dlg.dartOneSelector.comboBoxRuleType.selectByClass<DartzeeDartRuleEven>()
             dlg.dartTwoSelector.comboBoxRuleType.selectByClass<DartzeeDartRuleEven>()
             dlg.dartThreeSelector.comboBoxRuleType.selectByClass<DartzeeDartRuleEven>()
-            dlg.totalSelector.cbDesc.doClick()
-            dlg.totalSelector.comboBoxRuleType.selectByClass<DartzeeTotalRuleOdd>()
+            dlg.aggregateSelector.cbDesc.doClick()
+            dlg.aggregateSelector.comboBoxRuleType.selectByClass<DartzeeTotalRuleOdd>()
             dlg.btnOk.doClick()
         }
 
@@ -348,8 +348,8 @@ class TestDartzeeRuleCreationDialogDtoPopulation : AbstractTest()
     fun `Should populate the total rule correctly`()
     {
         val dlg = DartzeeRuleCreationDialog()
-        dlg.totalSelector.cbDesc.doClick()
-        dlg.totalSelector.comboBoxRuleType.selectByClass<DartzeeTotalRulePrime>()
+        dlg.aggregateSelector.cbDesc.doClick()
+        dlg.aggregateSelector.comboBoxRuleType.selectByClass<DartzeeTotalRulePrime>()
         dlg.btnOk.doClick()
 
         val rule = dlg.dartzeeRule!!
@@ -428,8 +428,8 @@ class TestDartzeeRuleCreationDialogInteraction : AbstractTest()
 
         dlg.tfName.text shouldBe "Inner → Outer → Odd"
 
-        dlg.totalSelector.cbDesc.doClick()
-        dlg.totalSelector.comboBoxRuleType.selectByClass<DartzeeTotalRuleOdd>()
+        dlg.aggregateSelector.cbDesc.doClick()
+        dlg.aggregateSelector.comboBoxRuleType.selectByClass<DartzeeTotalRuleOdd>()
 
         flushEdt()
 

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleCreationDialog.kt
@@ -353,7 +353,7 @@ class TestDartzeeRuleCreationDialogDtoPopulation : AbstractTest()
         dlg.btnOk.doClick()
 
         val rule = dlg.dartzeeRule!!
-        rule.totalRule!!.toDbString() shouldBe DartzeeTotalRulePrime().toDbString()
+        rule.aggregateRule!!.toDbString() shouldBe DartzeeTotalRulePrime().toDbString()
     }
 }
 

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleTile.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeRuleTile.kt
@@ -2,7 +2,7 @@ package dartzee.screen.dartzee
 
 import dartzee.core.helper.makeMouseEvent
 import dartzee.dartzee.DartzeeRuleDto
-import dartzee.dartzee.total.DartzeeTotalRuleLessThan
+import dartzee.dartzee.aggregate.DartzeeTotalRuleLessThan
 import dartzee.helper.AbstractTest
 import dartzee.helper.makeDartzeeRuleDto
 import dartzee.helper.makeTotalScoreRule
@@ -24,7 +24,7 @@ class TestDartzeeRuleTile: AbstractTest()
     @Test
     fun `Should escape special characters in the description`()
     {
-        val dto = makeDartzeeRuleDto(totalRule = makeTotalScoreRule<DartzeeTotalRuleLessThan>(20))
+        val dto = makeDartzeeRuleDto(aggregateRule = makeTotalScoreRule<DartzeeTotalRuleLessThan>(20))
 
         val tile = FakeDartzeeRuleTile(dto, 3)
 

--- a/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeTemplateSetupScreen.kt
+++ b/src/test/kotlin/dartzee/screen/dartzee/TestDartzeeTemplateSetupScreen.kt
@@ -4,7 +4,7 @@ import dartzee.core.helper.processKeyPress
 import dartzee.dartzee.DartzeeRuleDto
 import dartzee.dartzee.DartzeeTemplateFactory
 import dartzee.dartzee.dart.DartzeeDartRuleEven
-import dartzee.dartzee.total.DartzeeTotalRulePrime
+import dartzee.dartzee.aggregate.DartzeeTotalRulePrime
 import dartzee.db.DARTZEE_TEMPLATE
 import dartzee.db.DartzeeTemplateEntity
 import dartzee.db.GameEntity
@@ -271,7 +271,7 @@ class TestDartzeeTemplateSetupScreen: AbstractTest()
         val template = insertDartzeeTemplate()
 
         val ruleOne = makeDartzeeRuleDto(DartzeeDartRuleEven())
-        val ruleTwo = makeDartzeeRuleDto(totalRule = DartzeeTotalRulePrime())
+        val ruleTwo = makeDartzeeRuleDto(aggregateRule = DartzeeTotalRulePrime())
 
         ruleOne.toEntity(1, DARTZEE_TEMPLATE, template.rowId).saveToDatabase()
         ruleTwo.toEntity(2, DARTZEE_TEMPLATE, template.rowId).saveToDatabase()


### PR DESCRIPTION
Towards: https://trello.com/c/yGOcbxLu/181-structure-new-covid-rules

Refactors the total dartzee rules to be more generic aggregate rules, which operate on the list of segments. Adds a "darts are increasing" rule as a proof of concept for the sorts of extra rules that can be added with this. 