### PR TITLE
Distinct and repeat rules

### DIFF
--- a/src/main/kotlin/dartzee/dartzee/AbstractDartzeeRule.kt
+++ b/src/main/kotlin/dartzee/dartzee/AbstractDartzeeRule.kt
@@ -66,7 +66,9 @@ fun getAllAggregateRules(): List<AbstractDartzeeAggregateRule>
         DartzeeTotalRulePrime(),
         DartzeeAggregateRuleIncreasing(),
         DartzeeAggregateRuleDecreasing(),
-        DartzeeAggregateRuleSpread())
+        DartzeeAggregateRuleSpread(),
+        DartzeeAggregateRuleDistinctScores(),
+        DartzeeAggregateRuleRepeats())
 }
 fun parseDartRule(xmlStr: String) = parseRule(xmlStr, getAllDartRules())
 fun parseAggregateRule(xmlStr: String) = parseRule(xmlStr, getAllAggregateRules())

--- a/src/main/kotlin/dartzee/dartzee/DartzeeCalculator.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeCalculator.kt
@@ -45,7 +45,7 @@ class DartzeeCalculator: AbstractDartzeeCalculator()
             isValidCombination(it, rule, cachedCombinationResults) }
 
         val validSegments = validCombinations.map { it[dartsSoFar.size] }.distinct()
-        val scoringSegments = rule.getScoringSegments(validSegments)
+        val scoringSegments = rule.getScoringSegments(dartsSoFar, validSegments)
 
         val validPixelPossibility = validCombinations.map { mapCombinationToProbability(it) }.sum()
         val allProbabilities = allPossibilities.map { mapCombinationToProbability(it) }.sum()

--- a/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
@@ -32,15 +32,17 @@ data class DartzeeRuleDto(val dart1Rule: AbstractDartzeeDartRule?, val dart2Rule
 
     fun getSuccessTotal(darts: List<Dart>): Int
     {
-        dart1Rule ?: return sumScore(darts)
+        val dartsAfterAggregate = aggregateRule?.getScoringDarts(darts) ?: darts
+
+        dart1Rule ?: return sumScore(dartsAfterAggregate)
 
         if (dart2Rule != null)
         {
-            return sumScore(darts)
+            return sumScore(dartsAfterAggregate)
         }
         else
         {
-            val validDarts = darts.filter { dart1Rule.isValidDart(it) }
+            val validDarts = dartsAfterAggregate.filter { dart1Rule.isValidDart(it) }
             return sumScore(validDarts)
         }
     }

--- a/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
+++ b/src/main/kotlin/dartzee/dartzee/DartzeeRuleDto.kt
@@ -50,14 +50,28 @@ data class DartzeeRuleDto(val dart1Rule: AbstractDartzeeDartRule?, val dart2Rule
     /**
      * If this is a "Score X" rule, return the relevant segments
      */
-    fun getScoringSegments(validSegments: List<DartboardSegment>): List<DartboardSegment>
+    fun getScoringSegments(dartsSoFar: List<Dart>, validSegments: List<DartboardSegment>): List<DartboardSegment>
     {
+        val scoringSegments = getScoringSegmentsForAggregateRule(dartsSoFar, validSegments)
         if (dart1Rule == null || dart2Rule != null)
         {
-            return validSegments
+            return scoringSegments
         }
 
-        return validSegments.filter { dart1Rule.isValidSegment(it) }
+        return scoringSegments.filter { dart1Rule.isValidSegment(it) }
+    }
+    private fun getScoringSegmentsForAggregateRule(dartsSoFar: List<Dart>, validSegments: List<DartboardSegment>): List<DartboardSegment>
+    {
+        if (dartsSoFar.size == 2 && aggregateRule != null)
+        {
+            return validSegments.filter {
+                val scoringDartsAfterTwo = aggregateRule.getScoringDarts(dartsSoFar).size
+                val scoringDartsAfterThree = aggregateRule.getScoringDarts(dartsSoFar + Dart(it.score, it.getMultiplier())).size
+                scoringDartsAfterThree > scoringDartsAfterTwo
+            }
+        }
+
+        return validSegments
     }
 
 

--- a/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeAggregateRule.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/AbstractDartzeeAggregateRule.kt
@@ -1,9 +1,15 @@
 package dartzee.dartzee.aggregate
 
+import dartzee.`object`.Dart
 import dartzee.`object`.DartboardSegment
 import dartzee.dartzee.AbstractDartzeeRule
 
 abstract class AbstractDartzeeAggregateRule: AbstractDartzeeRule()
 {
     abstract fun isValidRound(segments: List<DartboardSegment>): Boolean
+
+    open fun getScoringDarts(darts: List<Dart>): List<Dart>
+    {
+        return darts
+    }
 }

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleDistinctScores.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleDistinctScores.kt
@@ -1,0 +1,19 @@
+package dartzee.dartzee.aggregate
+
+import dartzee.`object`.DartboardSegment
+
+class DartzeeAggregateRuleDistinctScores: AbstractDartzeeAggregateRule()
+{
+    override fun isValidRound(segments: List<DartboardSegment>): Boolean
+    {
+        if (segments.any { it.isMiss() })
+        {
+            return false
+        }
+
+        return segments.distinctBy { it.score }.size == 3
+    }
+
+    override fun getRuleIdentifier() = "DistinctScores"
+    override fun toString() = "Darts are distinct"
+}

--- a/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleRepeats.kt
+++ b/src/main/kotlin/dartzee/dartzee/aggregate/DartzeeAggregateRuleRepeats.kt
@@ -1,0 +1,22 @@
+package dartzee.dartzee.aggregate
+
+import dartzee.`object`.Dart
+import dartzee.`object`.DartboardSegment
+
+class DartzeeAggregateRuleRepeats: AbstractDartzeeAggregateRule()
+{
+    override fun isValidRound(segments: List<DartboardSegment>): Boolean
+    {
+        val nonMissGroups = segments.filterNot { it.isMiss() }.groupBy { it.score }.values
+        return nonMissGroups.firstOrNull { it.size > 1 } != null
+    }
+
+    override fun getRuleIdentifier() = "DartRepeats"
+    override fun toString() = "Score repeats"
+
+    override fun getScoringDarts(darts: List<Dart>): List<Dart>
+    {
+        val nonMissGroups = darts.filterNot { it.multiplier == 0 }.groupBy { it.score }.values
+        return nonMissGroups.firstOrNull { it.size > 1 } ?: emptyList()
+    }
+}

--- a/src/test/kotlin/dartzee/dartzee/TestDartzeeRuleDto.kt
+++ b/src/test/kotlin/dartzee/dartzee/TestDartzeeRuleDto.kt
@@ -1,5 +1,7 @@
 package dartzee.dartzee
 
+import dartzee.`object`.Dart
+import dartzee.dartzee.aggregate.DartzeeAggregateRuleRepeats
 import dartzee.dartzee.dart.*
 import dartzee.dartzee.aggregate.DartzeeTotalRuleGreaterThan
 import dartzee.dartzee.aggregate.DartzeeTotalRulePrime
@@ -162,7 +164,7 @@ class TestDartzeeRuleDto: AbstractTest()
         val validSegments = listOf(doubleNineteen, doubleTwenty)
 
         val rule = makeDartzeeRuleDto(aggregateRule = DartzeeTotalRulePrime())
-        rule.getScoringSegments(validSegments).shouldContainExactly(doubleNineteen, doubleTwenty)
+        rule.getScoringSegments(emptyList(), validSegments).shouldContainExactly(doubleNineteen, doubleTwenty)
     }
 
     @Test
@@ -171,7 +173,16 @@ class TestDartzeeRuleDto: AbstractTest()
         val validSegments = listOf(doubleNineteen, doubleTwenty)
 
         val rule = makeDartzeeRuleDto(makeScoreRule(19), DartzeeDartRuleOdd(), DartzeeDartRuleEven())
-        rule.getScoringSegments(validSegments).shouldContainExactly(doubleNineteen, doubleTwenty)
+        rule.getScoringSegments(emptyList(), validSegments).shouldContainExactly(doubleNineteen, doubleTwenty)
+    }
+
+    @Test
+    fun `Should return all validSegments as scoring segments if fewer than 2 darts thrown for aggregate rule`()
+    {
+        val validSegments = listOf(doubleNineteen, doubleTwenty)
+        val rule = makeDartzeeRuleDto(aggregateRule = DartzeeAggregateRuleRepeats())
+        val dartsSoFar = listOf(Dart(20, 1))
+        rule.getScoringSegments(dartsSoFar, validSegments).shouldContainExactly(doubleNineteen, doubleTwenty)
     }
 
     @Test
@@ -180,7 +191,16 @@ class TestDartzeeRuleDto: AbstractTest()
         val validSegments = listOf(doubleNineteen, doubleTwenty)
 
         val rule = makeDartzeeRuleDto(makeScoreRule(19))
-        rule.getScoringSegments(validSegments).shouldContainExactly(doubleNineteen)
+        rule.getScoringSegments(emptyList(), validSegments).shouldContainExactly(doubleNineteen)
+    }
+
+    @Test
+    fun `Should only return the segments that score if we are 2 darts into an aggregate rule`()
+    {
+        val validSegments = listOf(doubleNineteen, doubleTwenty)
+        val rule = makeDartzeeRuleDto(aggregateRule = DartzeeAggregateRuleRepeats())
+        val dartsSoFar = listOf(Dart(20, 1), Dart(20, 1))
+        rule.getScoringSegments(dartsSoFar, validSegments).shouldContainExactly(doubleTwenty)
     }
 
     @Test
@@ -245,5 +265,20 @@ class TestDartzeeRuleDto: AbstractTest()
 
         val otherDto = makeDartzeeRuleDto(otherScoreRule)
         otherDto.getSuccessTotal(dartsForTotal) shouldBe 10
+    }
+
+    @Test
+    fun `Should only sum the valid darts when tehre is an aggregate rule`()
+    {
+        val dto = makeDartzeeRuleDto(aggregateRule = DartzeeAggregateRuleRepeats())
+        dto.getSuccessTotal(dartsForTotal) shouldBe 40
+    }
+
+    @Test
+    fun `Should sum the intersection of valid darts when there is a score and aggregate rule`()
+    {
+        val dto = makeDartzeeRuleDto(makeColourRule(red = true), aggregateRule = DartzeeAggregateRuleRepeats())
+        val darts = listOf(makeDart(20, 1), makeDart(20, 3), makeDart(18, 3))
+        dto.getSuccessTotal(darts) shouldBe 60
     }
 }

--- a/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeAggregateRuleDistinctScores.kt
+++ b/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeAggregateRuleDistinctScores.kt
@@ -1,0 +1,34 @@
+package dartzee.dartzee.aggregate
+
+import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.helper.double
+import dartzee.helper.miss
+import dartzee.helper.outerSingle
+import dartzee.helper.treble
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+
+class TestDartzeeAggregateRuleDistinctScores: AbstractDartzeeRuleTest<DartzeeAggregateRuleDistinctScores>()
+{
+    override fun factory() = DartzeeAggregateRuleDistinctScores()
+
+    @Test
+    fun `Should not allow misses`()
+    {
+        factory().isValidRound(listOf(miss(20), outerSingle(11), double(3))) shouldBe false
+    }
+
+    @Test
+    fun `Should be valid if all scores are distinct`()
+    {
+        factory().isValidRound(listOf(outerSingle(20), treble(11), double(3))) shouldBe true
+    }
+
+    @Test
+    fun `Should not be valid if one or more scores are repeated`()
+    {
+        factory().isValidRound(listOf(outerSingle(20), treble(20), double(3))) shouldBe false
+        factory().isValidRound(listOf(outerSingle(20), double(20), treble(20))) shouldBe false
+        factory().isValidRound(listOf(outerSingle(5), outerSingle(10), double(5))) shouldBe false
+    }
+}

--- a/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeAggregateRuleRepeats.kt
+++ b/src/test/kotlin/dartzee/dartzee/aggregate/TestDartzeeAggregateRuleRepeats.kt
@@ -1,0 +1,51 @@
+package dartzee.dartzee.aggregate
+
+import dartzee.`object`.Dart
+import dartzee.dartzee.AbstractDartzeeRuleTest
+import dartzee.helper.double
+import dartzee.helper.miss
+import dartzee.helper.outerSingle
+import dartzee.helper.treble
+import dartzee.utils.sumScore
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+
+class TestDartzeeAggregateRuleRepeats: AbstractDartzeeRuleTest<DartzeeAggregateRuleRepeats>()
+{
+    override fun factory() = DartzeeAggregateRuleRepeats()
+
+    @Test
+    fun `Should not count a missed dart as a repeat`()
+    {
+        factory().isValidRound(listOf(miss(20), outerSingle(20), double(3))) shouldBe false
+    }
+
+    @Test
+    fun `Should be valid if at least one score is repeated`()
+    {
+        factory().isValidRound(listOf(outerSingle(20), treble(20), miss(3))) shouldBe true
+        factory().isValidRound(listOf(outerSingle(5), double(20), treble(5))) shouldBe true
+        factory().isValidRound(listOf(outerSingle(20), double(20), treble(20))) shouldBe true
+    }
+
+    @Test
+    fun `Should not be valid if all scores are distinct`()
+    {
+        factory().isValidRound(listOf(outerSingle(20), treble(5), double(3))) shouldBe false
+        factory().isValidRound(listOf(outerSingle(20), double(25), treble(14))) shouldBe false
+    }
+
+    @Test
+    fun `Should only score the darts that were repeats`()
+    {
+        factory().getScore(Dart(20, 1), Dart(20, 2), Dart(5, 1)) shouldBe 60
+        factory().getScore(Dart(5, 1), Dart(5, 2), Dart(5, 3)) shouldBe 30
+        factory().getScore(Dart(20, 1), Dart(20, 0), Dart(20, 1)) shouldBe 40
+        factory().getScore(Dart(5, 1), Dart(20, 0), Dart(5, 1)) shouldBe 10
+    }
+
+    private fun DartzeeAggregateRuleRepeats.getScore(vararg darts: Dart): Int
+    {
+        return sumScore(getScoringDarts(darts.toList()))
+    }
+}


### PR DESCRIPTION
Final step towards: https://trello.com/c/yGOcbxLu/181-structure-new-covid-rules

"Score repeats" plays a bit jankily if you combine it with another "score" rule, e.g. "Score Even". It also doesn't do dartboard highlighting quite as well as it could - e.g. after hitting two 20s it would ideally grey out the non-20 area to indicate that only another 20 will score you points. Not sure if I can be bothered to sort these, though...