### PR TITLE
Attempt to make file steps of sync more resilient

### DIFF
--- a/src/main/kotlin/dartzee/core/util/FileUtil.kt
+++ b/src/main/kotlin/dartzee/core/util/FileUtil.kt
@@ -27,13 +27,18 @@ object FileUtil {
         val newFile = File(newFilePath)
         val zzOldFile = File(oldFile.parent, "zz$oldFileName")
 
+        logger.info(CODE_SWITCHING_FILES, "Pre-delete [$zzOldFile] in case it exists already")
+        if (!zzOldFile.deleteRecursively()) {
+            return "Failed to tidy up before move."
+        }
+
         logger.info(CODE_SWITCHING_FILES, "Rename current out of the way [$oldFile -> $zzOldFile]")
-        if (oldFile.exists() && !oldFile.renameTo(zzOldFile)) {
+        if (oldFile.exists() && !oldFile.renameToWithRetries(zzOldFile)) {
             return "Failed to rename old out of the way."
         }
 
         logger.info(CODE_SWITCHING_FILES, "Rename new to current [$newFile -> $oldFile]")
-        if (!newFile.renameTo(File(oldFile.parent, oldFileName))) {
+        if (!newFile.renameToWithRetries(File(oldFile.parent, oldFileName))) {
             return "Failed to rename new file to $oldFileName"
         }
 
@@ -43,6 +48,38 @@ object FileUtil {
         }
 
         return null
+    }
+
+    tailrec fun File.renameToWithRetries(newFile: File, attempt: Int = 1): Boolean {
+        if (!exists()) {
+            logger.error(
+                CODE_FILE_ERROR,
+                "Trying to rename [$this] to [$newFile] but it does not exist",
+            )
+            return false
+        }
+
+        if (newFile.exists()) {
+            logger.error(
+                CODE_FILE_ERROR,
+                "Trying to rename [$this] to [$newFile] but [$newFile] already exists",
+            )
+            return false
+        }
+
+        val success = renameTo(newFile)
+        return if (success) {
+            true
+        } else if (attempt == 5) {
+            false
+        } else {
+            logger.warn(
+                CODE_FILE_ERROR,
+                "Failed to rename [$this] to [$newFile] on attempt $attempt, will retry.",
+            )
+            Thread.sleep(500)
+            renameToWithRetries(newFile, attempt + 1)
+        }
     }
 
     fun getImageDim(file: File): Dimension? {

--- a/src/main/kotlin/dartzee/logging/LoggingConsole.kt
+++ b/src/main/kotlin/dartzee/logging/LoggingConsole.kt
@@ -6,9 +6,11 @@ import dartzee.core.util.setMargins
 import dartzee.db.SqlStatementType
 import dartzee.screen.FocusableWindow
 import dartzee.utils.DartsDatabaseUtil
+import dartzee.utils.InjectedThings
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Component
+import java.io.File
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JScrollPane
@@ -92,6 +94,20 @@ class LoggingConsole : FocusableWindow(), ILogDestination {
             contextPanel.validate()
             contextPanel.repaint()
         }
+    }
+
+    fun getText(): String =
+        try {
+            doc.getText(0, doc.length)
+        } catch (t: Throwable) {
+            ""
+        }
+
+    fun dumpLogs() {
+        val f =
+            File("${System.getProperty("user.dir")}/logdump-${InjectedThings.clock.instant()}.txt")
+        f.createNewFile()
+        f.writeText(getText())
     }
 
     private fun factoryLabelForContext(field: Map.Entry<String, Any?>): Component {

--- a/src/main/kotlin/dartzee/logging/LoggingConsole.kt
+++ b/src/main/kotlin/dartzee/logging/LoggingConsole.kt
@@ -96,10 +96,11 @@ class LoggingConsole : FocusableWindow(), ILogDestination {
         }
     }
 
+    @Suppress("SwallowedException")
     fun getText(): String =
         try {
             doc.getText(0, doc.length)
-        } catch (t: Throwable) {
+        } catch (_: Throwable) {
             ""
         }
 

--- a/src/main/kotlin/dartzee/screen/DartsApp.kt
+++ b/src/main/kotlin/dartzee/screen/DartsApp.kt
@@ -36,6 +36,7 @@ private const val CMD_CLEAR_CONSOLE = "cls"
 private const val CMD_EMPTY_SCREEN_CACHE = "emptyscr"
 private const val CMD_GUID = "guid"
 private const val CMD_TEST = "test"
+private const val CMD_DUMP_LOGS = "dump logs"
 
 val APP_SIZE = Dimension(1000, 700)
 
@@ -166,6 +167,8 @@ class DartsApp(commandBar: CheatBar) : AbstractDevScreen(commandBar), WindowList
         } else if (cmd == CMD_TEST) {
             val window = TestWindow()
             window.isVisible = true
+        } else if (cmd == CMD_DUMP_LOGS) {
+            InjectedThings.loggingConsole.dumpLogs()
         }
 
         return textToShow

--- a/src/main/kotlin/dartzee/sync/SyncManager.kt
+++ b/src/main/kotlin/dartzee/sync/SyncManager.kt
@@ -23,6 +23,7 @@ import dartzee.utils.Database
 import dartzee.utils.DatabaseMigrations
 import dartzee.utils.InjectedThings.databaseDirectory
 import dartzee.utils.InjectedThings.logger
+import dartzee.utils.InjectedThings.loggingConsole
 import dartzee.utils.InjectedThings.mainDatabase
 import java.io.File
 import java.io.InterruptedIOException
@@ -136,6 +137,7 @@ class SyncManager(private val dbStore: IRemoteDatabaseStore) {
         SyncProgressDialog.dispose()
 
         if (!success) {
+            loggingConsole.dumpLogs()
             return null
         }
 

--- a/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
+++ b/src/main/kotlin/dartzee/utils/DartsDatabaseUtil.kt
@@ -190,7 +190,6 @@ object DartsDatabaseUtil {
     }
 
     fun swapInDatabase(otherDatabase: Database): Boolean {
-        // Now switch it in
         try {
             mainDatabase.shutDown()
             otherDatabase.shutDown()

--- a/src/test/kotlin/dartzee/core/util/FileUtilTest.kt
+++ b/src/test/kotlin/dartzee/core/util/FileUtilTest.kt
@@ -1,11 +1,16 @@
 package dartzee.core.util
 
+import dartzee.core.util.FileUtil.renameToWithRetries
 import dartzee.helper.AbstractTest
 import dartzee.logging.CODE_FILE_ERROR
 import dartzee.logging.Severity
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.file.shouldNotExist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
 import java.awt.Dimension
 import java.io.File
 import java.nio.file.DirectoryNotEmptyException
@@ -14,7 +19,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class TestFileUtil : AbstractTest() {
+class FileUtilTest : AbstractTest() {
     private val testDirectory = File("Test/")
 
     @BeforeEach
@@ -67,7 +72,7 @@ class TestFileUtil : AbstractTest() {
         new.createNewFile()
         new.writeText("New")
 
-        FileUtil.swapInFile(current.path, new.path)
+        FileUtil.swapInFile(current.path, new.path) shouldBe null
 
         new.exists() shouldBe false
         current.exists() shouldBe true
@@ -87,11 +92,103 @@ class TestFileUtil : AbstractTest() {
         new.createNewFile()
         new.writeText("New")
 
-        FileUtil.swapInFile("Test/Current", "Test/New")
+        FileUtil.swapInFile("Test/Current", "Test/New") shouldBe null
 
         new.exists() shouldBe false
         current.exists() shouldBe true
         current.readLines().shouldContainExactly("New")
+    }
+
+    @Test
+    fun `Should pre-clean for when a move has previously failed`() {
+        val zzDir = File("Test/zzCurrent")
+        zzDir.mkdir()
+
+        val inTheWay = File("Test/zzCurrent/Bad.txt")
+        inTheWay.createNewFile()
+        inTheWay.writeText("muahaha")
+
+        val currentDir = File("Test/Current")
+        currentDir.mkdir()
+        val newDir = File("Test/New")
+        newDir.mkdir()
+
+        val current = File("Test/Current/File.txt")
+        current.createNewFile()
+        current.writeText("Current")
+
+        val new = File("Test/New/File.txt")
+        new.createNewFile()
+        new.writeText("New")
+
+        FileUtil.swapInFile("Test/Current", "Test/New") shouldBe null
+
+        zzDir.shouldNotExist()
+        inTheWay.shouldNotExist()
+        newDir.shouldNotExist()
+        new.shouldNotExist()
+
+        currentDir.shouldExist()
+        current.shouldExist()
+        current.readLines().shouldContainExactly("New")
+    }
+
+    @Test
+    fun `Rename should fail for non-existent file`() {
+        val f = File("Test/Test.txt")
+
+        f.renameToWithRetries(File("Test/New.txt")) shouldBe false
+
+        val error = verifyLog(CODE_FILE_ERROR, Severity.ERROR)
+        error.message shouldBe
+            "Trying to rename [Test/Test.txt] to [Test/New.txt] but it does not exist"
+    }
+
+    @Test
+    fun `Rename should fail if destination already exists`() {
+        val f = File("Test/Test.txt")
+        f.createNewFile()
+        val new = File("Test/New.txt")
+        new.createNewFile()
+
+        f.renameToWithRetries(new) shouldBe false
+
+        val error = verifyLog(CODE_FILE_ERROR, Severity.ERROR)
+        error.message shouldBe
+            "Trying to rename [Test/Test.txt] to [Test/New.txt] but [Test/New.txt] already exists"
+    }
+
+    @Test
+    fun `Rename should succeed on retry`() {
+        val f = mockk<File>()
+        every { f.exists() } returns true
+
+        var counter = 0
+        every { f.renameTo(any()) } answers
+            {
+                if (counter < 2) {
+                    counter++
+                    false
+                } else {
+                    true
+                }
+            }
+
+        val new = File("Test/New.txt")
+        f.renameToWithRetries(new) shouldBe true
+
+        verifyLog(CODE_FILE_ERROR, Severity.WARN)
+    }
+
+    @Test
+    fun `Rename should give up on persistent failure`() {
+        val f = mockk<File>()
+        every { f.exists() } returns true
+        every { f.renameTo(any()) } returns false
+
+        val new = File("Test/New.txt")
+
+        f.renameToWithRetries(new) shouldBe false
     }
 
     @Test

--- a/src/test/kotlin/dartzee/helper/AbstractTest.kt
+++ b/src/test/kotlin/dartzee/helper/AbstractTest.kt
@@ -1,6 +1,7 @@
 package dartzee.helper
 
 import com.github.alyssaburlton.swingtest.SwingTestCleanupExtension
+import dartzee.CURRENT_TIME
 import dartzee.core.helper.TestMessageDialogFactory
 import dartzee.core.util.DialogUtil
 import dartzee.logging.LogDestinationSystemOut
@@ -20,6 +21,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.mockk
+import java.io.File
 import java.time.LocalDate
 import java.time.Month
 import org.junit.jupiter.api.AfterEach
@@ -32,6 +34,7 @@ private var checkedForExceptions = false
 
 const val TEST_ROOT = "Test/"
 const val TEST_DB_DIRECTORY = "Test/Databases"
+val LOG_DUMP_FILE = File("logdump-${CURRENT_TIME}.txt")
 
 @ExtendWith(BeforeAllTestsExtension::class)
 @ExtendWith(SwingTestCleanupExtension::class)

--- a/src/test/kotlin/dartzee/logging/LoggingConsoleTest.kt
+++ b/src/test/kotlin/dartzee/logging/LoggingConsoleTest.kt
@@ -1,9 +1,9 @@
 package dartzee.logging
 
 import com.github.alyssaburlton.swingtest.flushEdt
-import dartzee.CURRENT_TIME
 import dartzee.core.util.getAllChildComponentsForType
 import dartzee.helper.AbstractTest
+import dartzee.helper.LOG_DUMP_FILE
 import dartzee.makeLogRecord
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
@@ -12,18 +12,15 @@ import io.kotest.matchers.file.shouldExist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import java.awt.Color
-import java.io.File
 import javax.swing.JLabel
 import javax.swing.text.StyleConstants
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
 class LoggingConsoleTest : AbstractTest() {
-    private val DUMP_FILE = File("logdump-${CURRENT_TIME}.txt")
-
     @AfterEach
     fun afterEach() {
-        DUMP_FILE.delete()
+        LOG_DUMP_FILE.delete()
     }
 
     @Test
@@ -193,8 +190,8 @@ class LoggingConsoleTest : AbstractTest() {
         console.log(recordTwo)
         console.dumpLogs()
 
-        DUMP_FILE.shouldExist()
-        DUMP_FILE.readText() shouldBe "\n$recordOne\n$recordTwo"
+        LOG_DUMP_FILE.shouldExist()
+        LOG_DUMP_FILE.readText() shouldBe "\n$recordOne\n$recordTwo"
     }
 
     private fun LoggingConsole.getTextColour(position: Int = 0): Color {

--- a/src/test/kotlin/dartzee/logging/LoggingConsoleTest.kt
+++ b/src/test/kotlin/dartzee/logging/LoggingConsoleTest.kt
@@ -1,20 +1,31 @@
 package dartzee.logging
 
 import com.github.alyssaburlton.swingtest.flushEdt
+import dartzee.CURRENT_TIME
 import dartzee.core.util.getAllChildComponentsForType
 import dartzee.helper.AbstractTest
 import dartzee.makeLogRecord
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.file.shouldExist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import java.awt.Color
+import java.io.File
 import javax.swing.JLabel
 import javax.swing.text.StyleConstants
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
-class TestLoggingConsole : AbstractTest() {
+class LoggingConsoleTest : AbstractTest() {
+    private val DUMP_FILE = File("logdump-${CURRENT_TIME}.txt")
+
+    @AfterEach
+    fun afterEach() {
+        DUMP_FILE.delete()
+    }
+
     @Test
     fun `Should separate log records with a new line`() {
         val recordOne = makeLogRecord(loggingCode = LoggingCode("foo"), message = "log one")
@@ -172,12 +183,19 @@ class TestLoggingConsole : AbstractTest() {
         newLabels.map { it.text }.shouldContainExactly("appVersion: 4.1.1", "devMode: false")
     }
 
-    private fun LoggingConsole.getText(): String =
-        try {
-            doc.getText(0, doc.length)
-        } catch (t: Throwable) {
-            ""
-        }
+    @Test
+    fun `Should dump logs to file`() {
+        val recordOne = makeLogRecord(loggingCode = LoggingCode("foo"), message = "log one")
+        val recordTwo = makeLogRecord(loggingCode = LoggingCode("bar"), message = "log two")
+
+        val console = LoggingConsole()
+        console.log(recordOne)
+        console.log(recordTwo)
+        console.dumpLogs()
+
+        DUMP_FILE.shouldExist()
+        DUMP_FILE.readText() shouldBe "\n$recordOne\n$recordTwo"
+    }
 
     private fun LoggingConsole.getTextColour(position: Int = 0): Color {
         val style = doc.getCharacterElement(position)

--- a/src/test/kotlin/dartzee/sync/SyncManagerTest.kt
+++ b/src/test/kotlin/dartzee/sync/SyncManagerTest.kt
@@ -12,6 +12,7 @@ import dartzee.getDialogMessage
 import dartzee.getErrorDialog
 import dartzee.getInfoDialog
 import dartzee.helper.AbstractTest
+import dartzee.helper.LOG_DUMP_FILE
 import dartzee.helper.REMOTE_NAME
 import dartzee.helper.TEST_DB_DIRECTORY
 import dartzee.helper.getCountFromTable
@@ -20,6 +21,7 @@ import dartzee.helper.insertPlayer
 import dartzee.helper.shouldUpdateSyncScreen
 import dartzee.helper.syncDirectoryShouldNotExist
 import dartzee.helper.usingInMemoryDatabase
+import dartzee.logging.CODE_FILE_ERROR
 import dartzee.logging.CODE_REVERT_TO_PULL
 import dartzee.logging.CODE_SQL_EXCEPTION
 import dartzee.logging.CODE_SYNC_ERROR
@@ -29,6 +31,7 @@ import dartzee.runAsync
 import dartzee.utils.Database
 import dartzee.utils.InjectedThings
 import dartzee.utils.InjectedThings.mainDatabase
+import io.kotest.matchers.file.shouldExist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -44,7 +47,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class TestSyncManager : AbstractTest() {
+class SyncManagerTest : AbstractTest() {
     @BeforeEach
     fun beforeEach() {
         File(TEST_DB_DIRECTORY).mkdirs()
@@ -53,6 +56,7 @@ class TestSyncManager : AbstractTest() {
     @AfterEach
     fun afterEach() {
         File(TEST_DB_DIRECTORY).deleteRecursively()
+        LOG_DUMP_FILE.delete()
     }
 
     @Test
@@ -240,7 +244,7 @@ class TestSyncManager : AbstractTest() {
     }
 
     @Test
-    fun `Should show an error if something goes wrong swapping the database in`() {
+    fun `Should show an error if something goes wrong swapping the database in, and dump logs`() {
         usingDbWithTestFile { remoteDb ->
             remoteDb.getDirectory().deleteRecursively()
 
@@ -253,6 +257,9 @@ class TestSyncManager : AbstractTest() {
             error.getDialogMessage() shouldBe
                 "Failed to restore database. Error: Failed to rename new file to ${mainDatabase.dbName}"
             error.clickOk(async = true)
+
+            verifyLog(CODE_FILE_ERROR, Severity.ERROR)
+            LOG_DUMP_FILE.shouldExist()
 
             // Open a test connection so the tidy-up doesn't freak out about the db already being
             // shut down

--- a/src/test/kotlin/dartzee/sync/SyncManagerTest.kt
+++ b/src/test/kotlin/dartzee/sync/SyncManagerTest.kt
@@ -259,12 +259,13 @@ class SyncManagerTest : AbstractTest() {
             error.clickOk(async = true)
 
             verifyLog(CODE_FILE_ERROR, Severity.ERROR)
-            LOG_DUMP_FILE.shouldExist()
 
             // Open a test connection so the tidy-up doesn't freak out about the db already being
             // shut down
             t!!.join()
             remoteDb.testConnection()
+
+            LOG_DUMP_FILE.shouldExist()
         }
     }
 


### PR DESCRIPTION
Chris hit this error:

<img width="1001" height="690" alt="image" src="https://github.com/user-attachments/assets/fe4fb3f8-b569-4fa7-9d82-75ed442b4974" />

Not got lots to go on in logs, there was also a knock-on effect where subsequent attempts to pull (which would have got him back to a good state) failed because `zzDarts` was still in the way.